### PR TITLE
tracking: handle the case where values doesn't have a q value

### DIFF
--- a/src/controllers/tracking.js
+++ b/src/controllers/tracking.js
@@ -92,7 +92,7 @@ class ClickTracking extends Tracking {
    * @param {Object} values Key-value pair parameters to use in the pipeline.
    */
   tracking(values) {
-    const newQ = values[this.qParam];
+    const newQ = values[this.qParam] || "";
     const first3CharactersChanged = !newQ.startsWith(
       this.prevQ.substr(0, Math.min(newQ.length, 3))
     );


### PR DESCRIPTION
Values not having a `q` value is a normal situation and should not cause the code to error.