### PR TITLE
pipeline: add cancel search, use when clearing ui inputs

### DIFF
--- a/src/controllers/pipeline.js
+++ b/src/controllers/pipeline.js
@@ -122,6 +122,14 @@ class Pipeline {
   }
 
   /**
+   * Cancels the current search in progress
+   */
+  cancelSearch() {
+    // FIXME(tbillington): call abort on network request when using js sdk with xmlhttprequest
+    this.searchCount++;
+  }
+
+  /**
    * Clears the error, response, and response values from this object.
    * @param {Object} values Key-value pair parameters.
    */

--- a/src/ui/text/AutocompleteInput.js
+++ b/src/ui/text/AutocompleteInput.js
@@ -77,6 +77,7 @@ class AutocompleteInput extends React.Component {
     if (textValues[this.props.qParam]) {
       this.props.pipeline.search(this.props.values.get());
     } else {
+      this.props.pipeline.cancelSearch();
       this.props.pipeline.clearResponse(this.props.values.get());
     }
   };

--- a/src/ui/text/Input.js
+++ b/src/ui/text/Input.js
@@ -60,6 +60,7 @@ class Input extends React.Component {
     if (textValues[this.props.qParam]) {
       this.props.pipeline.search(this.props.values.get());
     } else {
+      this.props.pipeline.cancelSearch();
       this.props.pipeline.clearResponse(this.props.values.get());
     }
   };


### PR DESCRIPTION
Currently, if a search request completes after an input component has been cleared the results will still be used.

This change will prevent any searches currently in progress from being used after `pipeline.cancelSearch()` has been called.