### PR TITLE
controllers/analytics: add support for gtag analytics

### DIFF
--- a/src/controllers/analytics/ga.ts
+++ b/src/controllers/analytics/ga.ts
@@ -7,6 +7,12 @@ import {
   EVENT_ANALYTICS_RESULT_CLICKED
 } from "../../events";
 
+enum GoogleAnalyticsObjects {
+  UniversalAnalytics = "_ua",
+  AnalyticsJS = "ga",
+  GTag = "gtag"
+}
+
 export class GoogleAnalytics {
   private id: string | null;
   private param: string;
@@ -32,14 +38,12 @@ export class GoogleAnalytics {
 
     if (id !== undefined) {
       this.id = id;
-
-      // @ts-ignore: checking for the presense of ga
-    } else if (isFunction(window.ga)) {
-      this.id = "ga";
-
-      // @ts-ignore: checking for the presense of _ua
-    } else if (isFunction(window._ua)) {
-      this.id = "_ua";
+    } else if (isFunction(window[GoogleAnalyticsObjects.AnalyticsJS])) {
+      this.id = GoogleAnalyticsObjects.AnalyticsJS;
+    } else if (isFunction(window[GoogleAnalyticsObjects.UniversalAnalytics])) {
+      this.id = GoogleAnalyticsObjects.UniversalAnalytics;
+    } else if (isFunction(window[GoogleAnalyticsObjects.GTag])) {
+      this.id = GoogleAnalyticsObjects.GTag;
     } else {
       this.id = null;
     }
@@ -64,8 +68,13 @@ export class GoogleAnalytics {
         { [this.param]: body }
       );
 
-      // @ts-ignore: window is an object
-      window[this.id]("send", "pageview", pageAddress);
+      if (this.id === GoogleAnalyticsObjects.GTag) {
+        window[this.id]("event", "page_view", {
+          page_location: pageAddress
+        });
+      } else {
+        window[this.id]("send", "pageview", pageAddress);
+      }
     }
   }
 

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,3 @@
+interface Window {
+  [k: string]: any;
+}


### PR DESCRIPTION
Adds support for [gtag.js](https://developers.google.com/analytics/devguides/collection/gtagjs/).

@mish15 added you to this, as was a little confused by the analytics events we are sending. Is there are reason we are sending page views for search events, and not [search events](https://developers.google.com/analytics/devguides/collection/gtagjs/events) themselves?
I'm also not 100% across google analytics so just wanted to make sure I hadn't messed something up in the process of add the gtag support.