### PR TITLE
Search: wrap summary data to Search component

### DIFF
--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -24,28 +24,14 @@ export interface PipelineProps {
   summary: SummaryInterface | undefined;
 }
 
-export interface QueryValuesInterface {
-  filter: string;
-  q: string;
-  page: string;
-}
-
-export interface ValuesInterface {
-  q?: string;
-  "q.original"?: string;
-  "q.suggestions"?: string;
-}
-
-export interface ResponseInterface {
-  reads: number;
-  totalResults: number;
-  time: number;
+export interface PipelineResponseInterface {
+  [k: string]: string | number;
 }
 
 export interface SummaryInterface {
-  queryValues: QueryValuesInterface;
-  values: ValuesInterface;
-  response: ResponseInterface;
+  queryValues: PipelineResponseInterface;
+  values: PipelineResponseInterface;
+  response: PipelineResponseInterface;
 }
 
 export interface StateChangeOptions<Item> extends StateChangeOptions<Item> {}
@@ -140,11 +126,13 @@ export class Search extends React.PureComponent<SearchProps<any>, {}> {
             summary = {
               queryValues: (mapToObject(
                 response.getQueryValues()
-              ) as unknown) as QueryValuesInterface,
-              values: mapToObject(response.getValues()) as ValuesInterface,
+              ) as unknown) as PipelineResponseInterface,
+              values: mapToObject(
+                response.getValues()
+              ) as PipelineResponseInterface,
               response: (mapToObject(response.getResponse() as
                 | Map<string, any>
-                | undefined) as unknown) as ResponseInterface
+                | undefined) as unknown) as PipelineResponseInterface
             };
           }
 

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -21,11 +21,31 @@ export interface PipelineProps {
   suggestions: string[];
   results: Result[];
   completion: string;
-  summary: SummaryInterface;
+  summary: SummaryInterface | undefined;
 }
 
-interface SummaryInterface {
-  [k: string]: string | number;
+export interface QueryValuesInterface {
+  filter: string;
+  q: string;
+  page: string;
+}
+
+export interface ValuesInterface {
+  q?: string;
+  "q.original"?: string;
+  "q.suggestions"?: string;
+}
+
+export interface ResponseInterface {
+  reads: number;
+  totalResults: number;
+  time: number;
+}
+
+export interface SummaryInterface {
+  queryValues: QueryValuesInterface;
+  values: ValuesInterface;
+  response: ResponseInterface;
 }
 
 export interface StateChangeOptions<Item> extends StateChangeOptions<Item> {}
@@ -115,12 +135,16 @@ export class Search extends React.PureComponent<SearchProps<any>, {}> {
 
           const response =
             pipelines.search.response || pipelines.instant.response;
-          let summary = {};
+          let summary: SummaryInterface | undefined;
           if (response) {
             summary = {
-              ...mapToObject(response.getQueryValues()),
-              ...mapToObject(response.getValues()),
-              ...mapToObject(response.getResponse())
+              queryValues: (mapToObject(
+                response.getQueryValues()
+              ) as unknown) as QueryValuesInterface,
+              values: mapToObject(response.getValues()) as ValuesInterface,
+              response: (mapToObject(response.getResponse() as
+                | Map<string, any>
+                | undefined) as unknown) as ResponseInterface
             };
           }
 

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -9,7 +9,7 @@ import { PipelineConsumer } from "../context/pipeline";
 import { SearchFn, PaginateFn } from "../context/pipeline/context";
 import { Result } from "@sajari/sdk-js";
 
-import { isNotEmptyArray, isNotEmptyString } from "./utils";
+import { isNotEmptyArray, isNotEmptyString, mapToObject } from "./utils";
 
 export type SearchStateAndHelpers = ControllerStateAndHelpers<any> &
   PipelineProps;
@@ -21,6 +21,11 @@ export interface PipelineProps {
   suggestions: string[];
   results: Result[];
   completion: string;
+  summary: SummaryInterface;
+}
+
+interface SummaryInterface {
+  [k: string]: string | number;
 }
 
 export interface StateChangeOptions<Item> extends StateChangeOptions<Item> {}
@@ -97,6 +102,8 @@ export class Search extends React.PureComponent<SearchProps<any>, {}> {
             pipelines.instant.completion
           );
 
+          pipelines.instant;
+
           const results = isNotEmptyArray(
             (pipelines.search.response &&
               pipelines.search.response.getResults()) ||
@@ -105,6 +112,18 @@ export class Search extends React.PureComponent<SearchProps<any>, {}> {
               pipelines.instant.response.getResults()) ||
               []
           );
+
+          const response =
+            pipelines.search.response || pipelines.instant.response;
+          let summary = {};
+          if (response) {
+            summary = {
+              ...mapToObject(response.getQueryValues()),
+              ...mapToObject(response.getValues()),
+              ...mapToObject(response.getResponse())
+            };
+          }
+
           const paginate = pipelines.paginate;
           const instantSearch = pipelines.instant.search;
           const search = pipelines.search.search;
@@ -115,7 +134,8 @@ export class Search extends React.PureComponent<SearchProps<any>, {}> {
             search,
             results,
             suggestions,
-            completion
+            completion,
+            summary
           };
 
           return (

--- a/src/components/Search/utils.ts
+++ b/src/components/Search/utils.ts
@@ -7,3 +7,17 @@ export function isNotEmptyArray<T>(a: T, b: T): T {
 }
 
 export const isNotEmptyString = (a: string, b: string) => (a === "" ? b : a);
+
+export const mapToObject = (
+  map: Map<string, any> | undefined
+): { [k: string]: string | number } => {
+  const obj: { [k: string]: string | number } = {};
+  if (map) {
+    map.forEach((v, k) => {
+      if (typeof v === "string" || typeof v === "number") {
+        obj[k] = v;
+      }
+    });
+  }
+  return obj;
+};


### PR DESCRIPTION
**WHAT**:
I am using the `Search` component to build the interface for #102 but the UI requires data like `totalResults`, `q.original`, etc and I have to use `Consumer` to get these data.

**WHY**:
It's cumbersome to write nested render-prop components since we can do an update to use just `Search` only.

**HOW**:
Get all the needed data from `pipeline` methods like `getResults ` or `getResponse` and inject those to `summary` prop and pass to render prop function.