### PR TITLE
Fix emotion10 fail to compile

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,5 @@
 {
   "presets": [
-    "@emotion/babel-preset-css-prop",
     [
       "@babel/env",
       {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "@babel/preset-env": "^7.0.0",
     "@babel/preset-react": "^7.0.0",
     "@babel/preset-typescript": "^7.0.0",
-    "@emotion/babel-preset-css-prop": "^10.0.9",
     "@types/classnames": "^2.2.7",
     "@types/enzyme": "^3.1.13",
     "@types/i18next": "^11.9.0",

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,3 +1,5 @@
+/** @jsx jsx */ jsx;
+import { jsx } from "@emotion/core";
 /* tslint:disable max-classes-per-file */
 import { Result } from "@sajari/sdk-js";
 import { withTheme } from "emotion-theming";

--- a/src/components/Input/Results.tsx
+++ b/src/components/Input/Results.tsx
@@ -1,3 +1,5 @@
+/** @jsx jsx */ jsx;
+import { jsx } from "@emotion/core";
 import { SearchStateAndHelpers } from "../Search/Search";
 import * as React from "react";
 import { Config, defaultConfig } from "../../config";

--- a/src/components/Input/Suggestions.tsx
+++ b/src/components/Input/Suggestions.tsx
@@ -1,3 +1,5 @@
+/** @jsx jsx */ jsx;
+import { jsx } from "@emotion/core";
 import * as React from "react";
 import classnames from "classnames";
 import { Dropdown } from "./shared/Dropdown";

--- a/src/components/Input/Typeahead.tsx
+++ b/src/components/Input/Typeahead.tsx
@@ -1,3 +1,5 @@
+/** @jsx jsx */ jsx;
+import { jsx, css } from "@emotion/core";
 import * as React from "react";
 import { trimPrefix } from "./shared/utils";
 import { CSSObject } from "@emotion/core";

--- a/src/components/Input/shared/Dropdown.tsx
+++ b/src/components/Input/shared/Dropdown.tsx
@@ -1,3 +1,5 @@
+/** @jsx jsx */ jsx;
+import { jsx } from "@emotion/core";
 import { SearchStateAndHelpers } from "../../Search/Search";
 import * as React from "react";
 import { CSSObject } from "@emotion/core";

--- a/src/components/Paginator/Paginator.tsx
+++ b/src/components/Paginator/Paginator.tsx
@@ -1,3 +1,5 @@
+/** @jsx jsx */ jsx;
+import { jsx } from "@emotion/core";
 import * as React from "react";
 import classnames from "classnames";
 import { PaginateFn } from "../context/pipeline/context";

--- a/src/components/Result/Image.tsx
+++ b/src/components/Result/Image.tsx
@@ -1,3 +1,5 @@
+/** @jsx jsx */ jsx;
+import { jsx } from "@emotion/core";
 import * as React from "react";
 import classnames from "classnames";
 

--- a/src/components/Result/Result.tsx
+++ b/src/components/Result/Result.tsx
@@ -1,5 +1,6 @@
+/** @jsx jsx */ jsx;
+import { jsx, css } from "@emotion/core";
 import classnames from "classnames";
-import { css } from "@emotion/core";
 import { withTheme } from "emotion-theming";
 import idx from "idx";
 import * as React from "react";

--- a/src/components/Tabs/Tab/Tab.tsx
+++ b/src/components/Tabs/Tab/Tab.tsx
@@ -1,3 +1,5 @@
+/** @jsx jsx */ jsx;
+import { jsx } from "@emotion/core";
 import * as React from "react";
 import classnames from "classnames";
 import { FilterConsumer } from "../../context/filter";

--- a/src/docs/wrapper.tsx
+++ b/src/docs/wrapper.tsx
@@ -1,3 +1,5 @@
+/** @jsx jsx */ jsx;
+import { jsx } from "@emotion/core";
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 import { Provider } from "../components";

--- a/yarn.lock
+++ b/yarn.lock
@@ -546,7 +546,7 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-jsx" "^7.2.0"
 
-"@babel/plugin-transform-react-jsx@^7.0.0", "@babel/plugin-transform-react-jsx@^7.1.6":
+"@babel/plugin-transform-react-jsx@^7.0.0":
   version "7.3.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.3.0.tgz#f2cab99026631c767e2745a5368b331cfe8f5290"
   dependencies:
@@ -791,21 +791,6 @@
     esutils "^2.0.2"
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
-
-"@emotion/babel-plugin-jsx-pragmatic@^0.1.2":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@emotion/babel-plugin-jsx-pragmatic/-/babel-plugin-jsx-pragmatic-0.1.2.tgz#bb98bbef8effe83418307563c34e784deae57a1a"
-  dependencies:
-    "@babel/plugin-syntax-jsx" "^7.2.0"
-
-"@emotion/babel-preset-css-prop@^10.0.9":
-  version "10.0.9"
-  resolved "https://registry.yarnpkg.com/@emotion/babel-preset-css-prop/-/babel-preset-css-prop-10.0.9.tgz#70386bd88fe4d8896e1b9729364daf3a6051f726"
-  dependencies:
-    "@babel/plugin-transform-react-jsx" "^7.1.6"
-    "@emotion/babel-plugin-jsx-pragmatic" "^0.1.2"
-    babel-plugin-emotion "^10.0.9"
-    object-assign "^4.1.1"
 
 "@emotion/babel-utils@^0.6.4":
   version "0.6.10"
@@ -3629,14 +3614,6 @@ elliptic@^6.0.0:
 emojis-list@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
-
-emotion-theming@^10.0.10:
-  version "10.0.10"
-  resolved "https://registry.yarnpkg.com/emotion-theming/-/emotion-theming-10.0.10.tgz#efe8751119751bdc70fdc1795fe4cde0fb0cf14c"
-  dependencies:
-    "@emotion/weak-memoize" "0.2.2"
-    hoist-non-react-statics "^3.3.0"
-    object-assign "^4.1.1"
 
 emotion-theming@^10.0.10:
   version "10.0.10"


### PR DESCRIPTION
**WHAT**

Unable to compile styles of components after running `build` due to `TypeScript` (https://github.com/emotion-js/emotion/issues/1046)
```
<div css={styles} />
```
will be compiled to
```
<div css="[object Object]"></div>
```

**HOW**

Add jsx pragma on top of each component to get styles compiled

```
/** @jsx jsx */ jsx;
import { jsx } from "@emotion/core";
```