### PR TITLE
Input: fix hard to click drag to select text

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "i18next-browser-languagedetector": "^2.2.3",
     "js-cookie": "^2.2.0",
     "react-aria-live": "^2.0.2",
-    "react-input-autosize": "^2.2.1",
     "react-select": "^2.0.0"
   },
   "peerDependencies": {

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -4,8 +4,6 @@ import { jsx } from "@emotion/core";
 import { Result } from "@sajari/sdk-js";
 import { withTheme } from "emotion-theming";
 import * as React from "react";
-// @ts-ignore: component missing type defs
-import AutosizeInput from "react-input-autosize";
 import { Theme } from "../styles";
 import { ResultRendererProps, Results } from "./Results";
 import { Suggestions } from "./Suggestions";
@@ -308,11 +306,10 @@ export class Input extends React.PureComponent<InputProps, InputState> {
                     this.getButtonWidth() + this.getVoiceButtonWidth()
                   )}
                 >
-                  <AutosizeInput
-                    inputRef={this.inputRef}
-                    css={inputResetStyles.container}
-                    inputStyle={inputResetStyles.input}
-                    minWidth={5}
+                  <input
+                    type="text"
+                    ref={this.inputRef}
+                    css={[inputResetStyles.container, inputResetStyles.input]}
                     {...getInputProps({
                       "aria-label": this.props.ariaLabel,
                       placeholder: this.props.placeholder,
@@ -534,11 +531,8 @@ const inputContainerStyles = (isFocused: boolean) => ({
 });
 
 const innerContainerStyles = (buttonWidth: number): CSSObject => ({
-  display: "flex",
-  flex: "1 1 auto",
-  flexDirection: "row",
-  justifyContent: "start",
-  alignItems: "baseline",
+  position: "relative",
+  width: "100%",
   maxWidth: `calc(100% - ${buttonWidth}px)`
 });
 
@@ -560,6 +554,7 @@ const inputResetStyles = {
     border: 0,
     color: "inherit",
     fontFamily: "inherit",
+    width: "100%",
     fontSize: "inherit",
     outline: 0,
     padding: 0,

--- a/src/components/Input/Typeahead.tsx
+++ b/src/components/Input/Typeahead.tsx
@@ -12,20 +12,33 @@ interface TypeaheadProps {
 
 const typeaheadStyles: CSSObject = {
   color: "#bebebe",
-  display: "inline",
   fontSize: "1em",
-  marginLeft: -2,
-  position: "relative"
+  position: "absolute",
+  width: "100%",
+  overflow: "hiddden",
+  left: 0,
+  top: "50%",
+  transform: "translateY(-50%)",
+  pointerEvents: "none",
+  span: {
+    opacity: 0
+  }
 };
 
 export function Typeahead({ inputValue, completion, styles }: TypeaheadProps) {
   let typeaheadValue = "";
+  let hiddenText = "";
   if (completion) {
     typeaheadValue = trimPrefix(completion, inputValue);
+    hiddenText = completion.substring(
+      0,
+      completion.length - typeaheadValue.length
+    );
   }
 
   return (
     <div css={[typeaheadStyles, styles]} className="sj-input__typeahead">
+      <span>{hiddenText}</span>
       {typeaheadValue}
     </div>
   );


### PR DESCRIPTION
This PR aims to resolve https://github.com/sajari/website-search-integration/issues/11

WHAT:
It's hard for users to click + drag to select the text on the search box.

WHY:
The input was wrapped by `React-Autosize-Input` component in order to position . This implementation made the width of the input not span over its div container so users will actually click + drag on the div container rather than the input.

HOW:
- Remove the `React-Autosize-Input` component and force the width of the input to span over its parent box. 
- Keep the typeahead word without trimming, place it on the left-most of the search box and vertically center it. Finally, hide the substring of the actual input by `opacity:0`.

Here is the demo - https://codesandbox.io/s/8804qlkr02.