### PR TITLE
Tab: allow using keyboard to select tab

### DIFF
--- a/src/components/Tabs/Tab/Tab.tsx
+++ b/src/components/Tabs/Tab/Tab.tsx
@@ -7,6 +7,9 @@ import { FilterConsumer } from "../../context/filter";
 import { Container } from "./styled";
 import { CSSObject } from "@emotion/css";
 
+const ReturnKeyCode = 13;
+const SpaceKeyCode = 32;
+
 export interface TabProps {
   title: string;
   styles?: CSSObject;
@@ -21,6 +24,14 @@ export const Tab: React.SFC<TabProps> = ({ title, styles = {} }) => (
           className={classnames("sj-tabs__tab", {
             "sj-tabs__tab--selected": isSelected
           })}
+          role="button"
+          tabIndex={0}
+          onKeyDown={(e: React.KeyboardEvent<HTMLDivElement>) => {
+            if (e.keyCode === ReturnKeyCode || e.keyCode === SpaceKeyCode) {
+              e.preventDefault();
+              setFilter(set, title, !isSelected)();
+            }
+          }}
           isSelected={isSelected}
           onClick={setFilter(set, title, !isSelected)}
           css={styles}


### PR DESCRIPTION
This PR aims to resolve https://github.com/sajari/website-search-integration/issues/13

WHAT: 
Cannot use `tab` key to move focus on the tab button.

WHY:
Because of using `div` as the markup for tab buttons, the tag doesn't behave like the native `button`.

HOW:
Add `role` & `tab-index` attrs to let browsers identify tab buttons as a native button.
Add `keydown` event to preserve the click action by pressing `Enter` or `Space`.