### PR TITLE
fix select Input returns No Results prompt

### DIFF
--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -92,7 +92,6 @@ export class Input extends React.PureComponent<InputProps, InputState> {
   public render() {
     return (
       <Search
-        getA11yStatusMessage={() => ""}
         stateReducer={this.stateReducer}
         key={`sj-downshift-${this.props.defaultValue}`}
         defaultInputValue={this.props.defaultValue}
@@ -164,9 +163,10 @@ export class Input extends React.PureComponent<InputProps, InputState> {
                       autoCorrect: "off",
                       maxLength: 2048,
                       onFocus: event => {
-                        openMenu();
+                        if (Array.isArray(results) && results.length > 0) {
+                          openMenu();
+                        }
                         this.setState(state => ({ ...state, focused: true }));
-
                         typeof this.props.onFocus === "function" &&
                           this.props.onFocus(event);
                       },

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -92,6 +92,7 @@ export class Input extends React.PureComponent<InputProps, InputState> {
   public render() {
     return (
       <Search
+        getA11yStatusMessage={() => ""}
         stateReducer={this.stateReducer}
         key={`sj-downshift-${this.props.defaultValue}`}
         defaultInputValue={this.props.defaultValue}

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -84,8 +84,6 @@ export class Search extends React.PureComponent<SearchProps<any>, {}> {
             pipelines.instant.completion
           );
 
-          pipelines.instant;
-
           const results = isNotEmptyArray(
             (pipelines.search.response &&
               pipelines.search.response.getResults()) ||

--- a/src/components/context/pipeline/Provider.tsx
+++ b/src/components/context/pipeline/Provider.tsx
@@ -301,7 +301,7 @@ function debounce<F extends Procedure>(
     isImmediate: false
   }
 ): F {
-  let timeoutId: NodeJS.Timeout | undefined;
+  let timeoutId: number | undefined;
 
   return function(this: any, ...args: any[]) {
     const context = this;


### PR DESCRIPTION
**WHAT**:
when the user presses Tab and comes on the search box, a "No Results" prompt appears for the Voiceover utility

**WHY**:
~Because the downshift `getA11yStatusMessage` function will return "No results." if the list of items is empty - https://github.com/downshift-js/downshift#geta11ystatusmessage~
When input is focused, it will trigger `openmenu` which will call `getA11yStatusMessage`. Initially, there is no search results so the status message will be `no results` which will be called out by screen reader.

**HOW**:
~Passing a function to return empty string to disable the behavior (have tested and screen reader still works properly on suggestion dropdown)~
Checking to call `openmenu` only when at least one result is available. 