### PR TITLE
Add onChange props to Paginator component

### DIFF
--- a/src/components/Paginator/paginator.mdx
+++ b/src/components/Paginator/paginator.mdx
@@ -7,6 +7,7 @@ route: /components/paginator
 import { PropsTable, Playground } from "docz";
 import { GeneralWrapper } from "../../docs/wrapper.tsx";
 import { Paginator } from "./Paginator.tsx";
+import { useState } from "react";
 
 export default ({ children }) => <GeneralWrapper>{children}</GeneralWrapper>;
 
@@ -33,6 +34,20 @@ import { Paginator } from "@sajari/sdk-react";
       <button onClick={onClick}>{pageNumber}</button>
     )}
   />
+</Playground>
+
+### Listen for page change
+
+<Playground>
+  {() => {
+    const [state, setState] = useState();
+    return (
+      <>
+        <Paginator onChange={paginatorState => setState(paginatorState)} />
+        <p>State: {JSON.stringify(state)}</p>
+      </>
+    );
+  }}
 </Playground>
 
 ## Props


### PR DESCRIPTION
### What this PR does
Currently, the `Paginator` component provides no method to listen for page change to the outside components so the UI cannot update accordingly, this will add a `onChange` props that is invoked whenever page is change whether it's jumping to specific page, navigate backward or forward.