### PR TITLE
fix(paginator): add missing "type" attribute

### DIFF
--- a/src/components/Paginator/Paginator.tsx
+++ b/src/components/Paginator/Paginator.tsx
@@ -92,6 +92,7 @@ interface PageButtonProps {
 function PreviousPageButton(props: PageButtonProps) {
   return (
     <PageButton
+      type="button"
       isDisabled={props.isDisabled}
       onClick={props.onClick}
       aria-label="Goto Previous Page"


### PR DESCRIPTION
Add type attr to the previous page button