### PR TITLE
rename `name` to `id` and use that for filter instead of title

### DIFF
--- a/src/components/Tabs/Tab/Tab.tsx
+++ b/src/components/Tabs/Tab/Tab.tsx
@@ -11,14 +11,15 @@ const ReturnKeyCode = 13;
 const SpaceKeyCode = 32;
 
 export interface TabProps {
+  id: string;
   title: string;
   styles?: CSSObject;
 }
 
-export const Tab: React.SFC<TabProps> = ({ title, styles = {} }) => (
+export const Tab: React.SFC<TabProps> = ({ id, title, styles = {} }) => (
   <FilterConsumer>
     {({ selected, set }) => {
-      const isSelected = selected.includes(title);
+      const isSelected = selected.includes(id);
       return (
         <Container
           className={classnames("sj-tabs__tab", {
@@ -29,11 +30,11 @@ export const Tab: React.SFC<TabProps> = ({ title, styles = {} }) => (
           onKeyDown={(e: React.KeyboardEvent<HTMLDivElement>) => {
             if (e.keyCode === ReturnKeyCode || e.keyCode === SpaceKeyCode) {
               e.preventDefault();
-              setFilter(set, title, !isSelected)();
+              setFilter(set, id, !isSelected)();
             }
           }}
           isSelected={isSelected}
-          onClick={setFilter(set, title, !isSelected)}
+          onClick={setFilter(set, id, !isSelected)}
           css={styles}
         >
           {title}
@@ -44,11 +45,11 @@ export const Tab: React.SFC<TabProps> = ({ title, styles = {} }) => (
 );
 
 type SetFn = (name: string, value: boolean) => void;
-const setFilter = (set: SetFn, name: string, value: boolean) => () => {
+const setFilter = (set: SetFn, id: string, value: boolean) => () => {
   if (!value) {
     // make tab act like radio button
     return;
   }
 
-  set(name, value);
+  set(id, value);
 };

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -8,7 +8,7 @@ import { Tab } from "./Tab";
 
 export interface TabsProps {
   filter: Filter;
-  tabs: Array<{ name: string; display: string }>;
+  tabs: Array<{ id: string; display: string }>;
   styles?: {
     container?: CSSObject;
     tab?: CSSObject;
@@ -20,7 +20,12 @@ export const Tabs: React.SFC<TabsProps> = ({ filter, tabs, styles = {} }) => (
     <Container className="sj-tabs" styles={styles.container}>
       <TabsContainer>
         {tabs.map(tab => (
-          <Tab key={tab.name} title={tab.display} styles={styles.tab} />
+          <Tab
+            key={tab.id}
+            id={tab.id}
+            title={tab.display}
+            styles={styles.tab}
+          />
         ))}
       </TabsContainer>
     </Container>

--- a/src/components/Tabs/tabs.mdx
+++ b/src/components/Tabs/tabs.mdx
@@ -15,7 +15,10 @@ import { Tabs } from "./Tabs.tsx";
 <ExampleContainer>
   <Tabs
     filter={categoryFilter()}
-    tabs={[{ name: "All", display: "All" }, { name: "Blog", display: "Blog" }]}
+    tabs={[
+      { id: "All", display: "All" },
+      { id: "Blog", display: "Blog" }
+    ]}
   />
 </ExampleContainer>
 
@@ -32,7 +35,10 @@ const filter = new Filter(
 
 <Tabs
   filter={filter}
-  tabs={[{ name: "All", display: "All" }, { name: "Blog", display: "Blog" }]}
+  tabs={[
+    { id: "All", display: "All" },
+    { id: "Blog", display: "Blog" }
+  ]}
 />;
 ```
 


### PR DESCRIPTION
Fixes #107 
- [x] Rename `name` key to `id` to make more sense and use it to for filter id instead of title (displayname)