### PR TITLE
components/result: fix 404 warning due to undefined image

### DIFF
--- a/src/components/Result/Image.tsx
+++ b/src/components/Result/Image.tsx
@@ -1,5 +1,5 @@
 /** @jsx jsx */ jsx;
-import { jsx } from "@emotion/core";
+import { CSSObject, jsx } from "@emotion/core";
 import classnames from "classnames";
 import * as React from "react";
 
@@ -9,7 +9,7 @@ export interface ImageProps {
   className?: string;
 }
 
-const imageStyles = {
+const imageStyles: CSSObject = {
   minWidth: 90,
   minHeight: 90,
   width: 90,
@@ -22,11 +22,15 @@ const imageStyles = {
 
 export function Image(props: ImageProps) {
   const { src } = props;
+  const styles = [imageStyles];
+  if (src) {
+    styles.push({ backgroundImage: `url(${src})` });
+  }
 
   return (
     <div
       role="presentation"
-      css={[imageStyles, { backgroundImage: `url(${src})` }]}
+      css={styles}
       className={classnames("sj-results__result__image", props.className)}
     />
   );


### PR DESCRIPTION
**What**: there is 404 error warning in case a record doesn't have a preview image

**Why**: in case `src` is undefined, we still use it as the value for `background-image`

**How**: check only adding `background-image` if the `src` does exist


![Screen Shot 2020-07-25 at 11 20 36 AM](https://user-images.githubusercontent.com/12707960/88448564-5a4b6580-ce69-11ea-8a14-67ed279cf9f1.png)