### PR TITLE
components/input: fix aria-labelledby reference warning

### DIFF
--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -132,10 +132,12 @@ export class Input extends React.PureComponent<InputProps, InputState> {
           const resetFunc = (event: React.MouseEvent<HTMLButtonElement>) => {event.preventDefault(); setState({type: Search.stateChangeTypes.resetInput as StateChangeTypes})}
           return (
             <div
-              {
-                // @ts-ignore
-                ...getRootProps({}, { suppressRefError: true })
-              }
+              {...getRootProps(
+                // skip labelledby becasuse there is no label associated to the input by getLabelProps
+                // @ts-ignore warning due to incorrect type definition for the param
+                { "aria-labelledby": undefined },
+                { suppressRefError: true }
+              )}
               className="sj-input"
               css={
                 this.props.styles &&


### PR DESCRIPTION
**WHAT**: broken ARIA reference warning

![image](https://user-images.githubusercontent.com/12707960/92625893-6b561600-f2f3-11ea-97ff-f3e3e59b38e5.png)

**WHY**:  `aria-labelledby` is injected to the parent div via `getRootProps` but the include doesn't have a label with the `getLabelProps` spreading.

**HOW**: since we've already defined `aria-label` for the input, just need to omit `aria-labelledby` from being added by `getRootProps`.