### PR TITLE
V3: fix: pageSize not reactive

### DIFF
--- a/docs/pages/hooks/usepagesize.mdx
+++ b/docs/pages/hooks/usepagesize.mdx
@@ -29,8 +29,14 @@ function Example() {
 
   const SearchPlayground = React.memo(() => {
     const { search, results } = useSearchContext();
-    const { setPageSize } = usePageSize();
+    const { pageSize, setPageSize } = usePageSize();
     const [query, setQuery] = React.useState('');
+
+    React.useEffect(() => {
+      if (query) {
+        search(query);
+      }
+    }, [pageSize]);
 
     return (
       <div className="flex flex-col space-y-4">
@@ -48,7 +54,7 @@ function Example() {
             <Input label="Search something" onChange={(e) => setQuery(e.target.value)} />
           </form>
           <div className="w-2/5">
-            <Select onChange={(e) => setPageSize(parseInt(e.target.value), 10)} placeholder="Select page size">
+            <Select value={`${pageSize}`} onChange={(e) => setPageSize(parseInt(e.target.value), 10)}>
               <option value="3">3</option>
               <option value="5">5</option>
               <option value="10">10</option>

--- a/packages/hooks/src/usePageSize/index.ts
+++ b/packages/hooks/src/usePageSize/index.ts
@@ -1,6 +1,5 @@
 import React from 'react';
 import { useContext } from '../SearchContextProvider';
-import usePagination from '../usePagination';
 import { UsePageSizeResult } from './types';
 
 function usePageSize(): UsePageSizeResult {
@@ -10,7 +9,6 @@ function usePageSize(): UsePageSizeResult {
       values,
     },
   } = useContext();
-  const { pageSize } = usePagination('search');
 
   const setPageSize = React.useCallback(
     (size: number) => {
@@ -19,8 +17,10 @@ function usePageSize(): UsePageSizeResult {
     [values],
   );
 
+  const pageSize = parseInt(values.get()[resultsPerPageParam], 10);
+
   return {
-    pageSize,
+    pageSize: Number.isNaN(pageSize) ? 10 : pageSize,
     setPageSize,
   };
 }


### PR DESCRIPTION
## Why does this PR exist?
Initially `usePageSize` composed `usePagination` - particularly `pageSize` variable - but since that value in `usePagination` is derived from the `response` which is only updated between search request so it doesn't make sense as page size is something user can update client-side and as a result changes to `pageSize` from `usePageSize` cannot be picked up by React.

## What does this PR do?
- [x] Change the `pageSize` to be derived from the `values` itself.