### PR TITLE
V3: chore: improve field mapping

### DIFF
--- a/docs/components/SearchProvider.tsx
+++ b/docs/components/SearchProvider.tsx
@@ -1,8 +1,8 @@
-import { Pipeline, SearchContextProvider, Values } from '@sajari/react-hooks';
+import { Pipeline, SearchContextProvider, Values, SearchProviderValues, FieldDictionary } from '@sajari/react-hooks';
 import { useRef } from 'react';
 
 const SearchProvider: React.FC = ({ children }) => {
-  const ref = useRef({
+  const ref = useRef<SearchProviderValues['search']>({
     pipeline: new Pipeline(
       {
         project: '1594153711901724220',
@@ -12,7 +12,7 @@ const SearchProvider: React.FC = ({ children }) => {
       'query',
     ),
     values: new Values({ q: '' }),
-    fields: { category: 'brand', title: 'name' },
+    fields: new FieldDictionary({ category: 'brand', title: 'name' }),
   });
 
   return <SearchContextProvider search={ref.current}>{children}</SearchContextProvider>;

--- a/docs/pages/hooks/usepagesize.mdx
+++ b/docs/pages/hooks/usepagesize.mdx
@@ -65,7 +65,16 @@ function Example() {
   });
 
   return (
-    <SearchContextProvider search={{ pipeline, values, fields: { category: 'brand', title: 'name' } }}>
+    <SearchContextProvider
+      search={{
+        pipeline,
+        values,
+        fields: {
+          category: (data) => data.level4 || data.level3 || data.level2 || data.level1 || data.brand,
+          title: 'name',
+        },
+      }}
+    >
       <SearchPlayground />
     </SearchContextProvider>
   );

--- a/example/index.tsx
+++ b/example/index.tsx
@@ -2,7 +2,7 @@ import 'react-app-polyfill/ie11';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { ContextProvider } from '@sajari/react-search-ui';
-import { SearchContextProvider, Pipeline, Values, useSearchContext } from '@sajari/react-hooks';
+import { SearchContextProvider, Pipeline, Values, useSearchContext, FieldDictionary } from '@sajari/react-hooks';
 import { Pagination } from '@sajari/react-components';
 
 const SearchPlayground = () => {
@@ -71,7 +71,9 @@ const values = new Values({ q: '' });
 
 const App = () => {
   return (
-    <SearchContextProvider search={{ pipeline, values, fields: { category: 'brand', title: 'name' } }}>
+    <SearchContextProvider
+      search={{ pipeline, values, fields: new FieldDictionary({ category: 'brand', title: 'name' }) }}
+    >
       <ContextProvider>
         <SearchPlayground />
       </ContextProvider>

--- a/packages/hooks/src/SearchContextProvider/index.tsx
+++ b/packages/hooks/src/SearchContextProvider/index.tsx
@@ -22,6 +22,7 @@ import {
   ProviderPipelineConfig,
   ProviderPipelineState,
   SearchProviderValues,
+  FieldDictionary,
 } from './types';
 
 const updateState = (query: string, responseValues: Map<string, string> | undefined, config: Config) => {
@@ -230,5 +231,5 @@ const SearchContextProvider: React.FC<SearchProviderValues> = ({
 };
 
 export default SearchContextProvider;
-export { ClickTracking, PosNegTracking, useContext, Pipeline, Values, RangeFilter, Range };
+export { ClickTracking, PosNegTracking, useContext, Pipeline, Values, RangeFilter, Range, FieldDictionary };
 export type { SearchProviderValues };

--- a/packages/hooks/src/SearchContextProvider/types.ts
+++ b/packages/hooks/src/SearchContextProvider/types.ts
@@ -16,14 +16,14 @@ export interface PipelineContextState {
   config: Config;
   search: SearchFn;
   clear: ClearFn;
-  fields?: Fields;
+  fields?: FieldDictionary;
 }
 
 export interface ProviderPipelineConfig {
   pipeline: Pipeline;
   values: Values;
   config?: Config;
-  fields?: Fields;
+  fields?: FieldDictionary;
 }
 
 export interface ProviderPipelineState {
@@ -32,14 +32,6 @@ export interface ProviderPipelineState {
   config: Config;
   completion: string;
   suggestions: string[];
-}
-
-export interface Fields {
-  title?: string;
-  description?: string;
-  price?: string;
-  rating?: string;
-  category?: string;
 }
 
 export interface SearchProviderValues {
@@ -58,4 +50,49 @@ export interface Context {
   instant: PipelineContextState;
   resultClicked: ResultClickedFn;
   paginate: PaginateFn;
+}
+
+type Field = ((data: Record<string, any>) => any) | string | string[];
+export class FieldDictionary {
+  id?: Field;
+
+  url?: Field;
+
+  title?: Field;
+
+  description?: Field;
+
+  price?: Field;
+
+  category?: Field;
+
+  rating?: Field;
+
+  inventory?: Field;
+
+  image?: Field;
+
+  constructor(input?: FieldDictionary) {
+    const {
+      id = '_id',
+      url = 'url',
+      title = 'title',
+      description = 'description',
+      price = 'price',
+      category = 'category',
+      rating = 'rating',
+      inventory = 'inventory',
+      image = 'image',
+    } = input ?? {};
+
+    this.id = id;
+    this.url = url;
+    this.title = title;
+    this.description = description;
+    this.price = price;
+    this.category = category;
+    this.rating = rating;
+    this.inventory = inventory;
+    this.image = image;
+  }
 }

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -9,6 +9,7 @@ export {
   RangeFilter,
   ClickTracking,
   PosNegTracking,
+  FieldDictionary,
 } from './SearchContextProvider';
 export { default as useSearchContext } from './useSearchContext';
 export { default as usePagination } from './usePagination';

--- a/packages/hooks/src/useSearch/index.ts
+++ b/packages/hooks/src/useSearch/index.ts
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { useContext } from '../SearchContextProvider';
 import { Pipeline, Response, Values } from '../SearchContextProvider/controllers';
 import { EVENT_RESPONSE_UPDATED } from '../SearchContextProvider/events';
-import { Fields } from '../SearchContextProvider/types';
+import { FieldDictionary } from '../SearchContextProvider/types';
 import debounce from '../utils/debounce';
 import mapResultFields from '../utils/mapResultFields';
 import mapToObject from '../utils/mapToObject';
@@ -65,7 +65,7 @@ function useSearchCustomQuery<T>(query: string) {
 }
 
 // Returns results for pass in Values and Pipeline
-function useSearchCustomPipeline<T>(values: Values, pipeline: Pipeline, fields?: Fields) {
+function useSearchCustomPipeline<T>(values: Values, pipeline: Pipeline, fields?: FieldDictionary) {
   // TODO: dirty way to get the return type of a generic function
   function inferTypeFunction(...args) {
     // @ts-ignore
@@ -96,7 +96,9 @@ function useSearchCustomPipeline<T>(values: Values, pipeline: Pipeline, fields?:
   return searchOutput;
 }
 
-function useSearch<T = Record<string, string | string[]>>(...args: [] | [string] | [Values, Pipeline, Fields]) {
+function useSearch<T = Record<string, string | string[]>>(
+  ...args: [] | [string] | [Values, Pipeline, FieldDictionary]
+) {
   if (args[0] instanceof Values && args[1] instanceof Pipeline && args[2]) {
     return useSearchCustomPipeline<T>(args[0], args[1], args[2]);
   }

--- a/packages/hooks/src/utils/mapResultFields.ts
+++ b/packages/hooks/src/utils/mapResultFields.ts
@@ -1,22 +1,45 @@
 import { Result } from '@sajari/sdk-js';
 
-import { Fields } from '../SearchContextProvider/types';
+import { FieldDictionary } from '../SearchContextProvider/types';
 
-export function mapFields<T = Record<string, string | string[]>>(values: T, fields: Fields = {}) {
-  const mappingFields = { ...values };
+const fillTemplate = <T = Record<string, string | string[]>>(template: string, variables: T) =>
+  template.replace(/\${(.*?)}/g, (_, g: string) => variables[g].toString());
 
-  Object.entries(fields).forEach(([key, mapKey]) => {
-    const value = values[mapKey];
-    if (value) {
-      mappingFields[key] = value;
-      delete mappingFields[mapKey];
-    }
-  });
+export function mapFields<T = Record<string, string | string[]>>(values: T, fields: FieldDictionary = {}) {
+  return Object.entries(fields).reduce(
+    (mapped, [to, from]) => {
+      let value;
+      if (Array.isArray(from)) {
+        const match = from.find((f) => {
+          return Object.keys(values).includes(f);
+        }) as string;
+        value = values[match];
+      } else if (typeof from === 'function') {
+        value = from(values);
+      } else if (from.startsWith('`') && from.endsWith('`')) {
+        const template = from.substring(1, from.length - 1);
+        value = fillTemplate<T>(template, values);
+      } else if (from.startsWith('!function')) {
+        const functionBody = from.replace('!function', '');
+        const func = new Function('data', functionBody);
+        value = func(values);
+      } else {
+        value = values[from];
+      }
 
-  return mappingFields as Record<keyof Fields, string | string[]> & T;
+      return {
+        ...mapped,
+        [to]: value,
+      };
+    },
+    { ...values },
+  );
 }
 
-export default function mapResultFields<T = Record<string, string | string[]>>(results: Result[], fields: Fields) {
+export default function mapResultFields<T = Record<string, string | string[]>>(
+  results: Result[],
+  fields: FieldDictionary,
+) {
   return results.map(({ values, ...rest }) => ({
     ...rest,
     // @ts-ignore

--- a/packages/hooks/src/utils/test/mapResultFields.test.ts
+++ b/packages/hooks/src/utils/test/mapResultFields.test.ts
@@ -1,9 +1,27 @@
 import { mapFields } from '../mapResultFields';
 
 test.each([
-  [{ brand: 'Sajari', title: 'Lorem' }, { category: 'brand' }, { category: 'Sajari', title: 'Lorem' }],
-  [{ title: 'Ipsum', cost: '12.3' }, { price: 'cost' }, { title: 'Ipsum', price: '12.3' }],
+  [{ brand: 'Sajari', title: 'Lorem' }, { category: 'brand' }, { brand: 'Sajari', category: 'Sajari', title: 'Lorem' }],
+  [{ title: 'Ipsum', cost: '12.3' }, { price: 'cost' }, { title: 'Ipsum', price: '12.3', cost: '12.3' }],
   [{ desc: 'Lorem ipsum' }, {}, { desc: 'Lorem ipsum' }],
+  [{ max_price: 10 }, { price: ['variant_price', 'max_price'] }, { price: 10, max_price: 10 }],
+  [
+    { handle: 'a-sample-slug' },
+    { url: '`/products/${handle}`' },
+    { url: '/products/a-sample-slug', handle: 'a-sample-slug' },
+  ],
+  [
+    { level2: 'category_1 > category_2', level1: 'category_1' },
+    { category: (data) => data.level4 || data.level3 || data.level2 || data.level1 },
+    { category: 'category_1 > category_2', level2: 'category_1 > category_2', level1: 'category_1' },
+  ],
+  [
+    {},
+    {
+      category: "!function return 'the category'",
+    },
+    { category: 'the category' },
+  ],
 ])('mapFields(%o, %o)', (values, fields, expected) => {
   expect(mapFields(values, fields)).toStrictEqual(expected);
 });

--- a/packages/search-ui/src/Results/index.tsx
+++ b/packages/search-ui/src/Results/index.tsx
@@ -14,20 +14,22 @@ const Results = (props: ResultsProps) => {
 
   return (
     <div css={[styles.container]}>
-      {results?.map(({ values: { category, description, image, _id, price, rating, title, url } }) => (
-        <Result
-          key={_id}
-          title={title}
-          url={url}
-          category={category.toString()}
-          description={description}
-          image={image}
-          price={price.toString()}
-          rating={Number(rating)}
-          appearance={appearance}
-          css={styles.item}
-        />
-      ))}
+      {results?.map(({ values: { category, description, image, _id, price, rating, title, url } }) => {
+        return (
+          <Result
+            key={_id}
+            title={title}
+            url={url}
+            category={category.toString()}
+            description={description}
+            image={image}
+            price={price.toString()}
+            rating={Number(rating)}
+            appearance={appearance}
+            css={styles.item}
+          />
+        );
+      })}
     </div>
   );
 };


### PR DESCRIPTION
## What does this PR do?
- [x] Add support for field array lookup:
```js
{
 category: ["level3", "level2", "level1"]
/**
*  ^ This will lookup "level3" field in 
* the response object and if it's not found then fallback to lookup "level2" and so forth
*/
}
```
- [x] Add support for parsing template literal:
```js
{
 url: "`/products/${slug}`"
/**
* ^ `slug` is a field in the response object, note the backticks
*/
}
```
- [x] Add support for function as value, the paramter is the response object:
```js
{
 category: (data) => data.level3 || data.level2 || data.level1 || "Unknown"
}
```
It also support function's body as a string:
```js
{
 category: "!function return 'Phone'"
/**
* ^ Note the `!function`
*/
}
```