### PR TITLE
V3: refactor: rewrite useSearch hook

### DIFF
--- a/docs/pages/hooks/usepagesize.mdx
+++ b/docs/pages/hooks/usepagesize.mdx
@@ -9,7 +9,7 @@ import SEO from '../../components/SEO';
 ```js
 import { Results } from '@sajari/react-search-ui';
 import { Pagination, Select, Input } from '@sajari/react-components';
-import { usePageSize, useSearchContext, SearchContextProvider, Pipeline, Values } from '@sajari/react-hooks';
+import { usePageSize, useSearch, SearchContextProvider, Pipeline, Values } from '@sajari/react-hooks';
 ```
 
 ## Usage
@@ -28,15 +28,9 @@ function Example() {
   const values = new Values({ q: '' });
 
   const SearchPlayground = React.memo(() => {
-    const { search, results } = useSearchContext();
+    const { search, results } = useSearch();
     const { pageSize, setPageSize } = usePageSize();
     const [query, setQuery] = React.useState('');
-
-    React.useEffect(() => {
-      if (query) {
-        search(query);
-      }
-    }, [pageSize]);
 
     return (
       <div className="flex flex-col space-y-4">
@@ -48,7 +42,7 @@ function Example() {
               search(query);
             }}
           >
-            <Input label="Search something" onChange={(value) => setQuery(value)} />
+            <Input label="Search something" value={query} onChange={(value) => setQuery(value)} />
           </form>
           <div className="w-2/5">
             <Select value={`${pageSize}`} onChange={(e) => setPageSize(parseInt(e.target.value), 10)}>

--- a/docs/pages/hooks/usepagination.mdx
+++ b/docs/pages/hooks/usepagination.mdx
@@ -12,7 +12,7 @@ import SEO from '../../components/SEO';
 ```js
 import { Results } from '@sajari/react-search-ui';
 import { Pagination, Input } from '@sajari/react-components';
-import { usePagination, SearchContextProvider, Pipeline, Values } from '@sajari/react-hooks';
+import { usePagination, useSearch, SearchContextProvider, Pipeline, Values } from '@sajari/react-hooks';
 ```
 
 ## Usage
@@ -31,7 +31,7 @@ function Example() {
   const values = new Values({ q: '' });
 
   const SearchPlayground = React.memo(() => {
-    const { search, results } = useSearchContext();
+    const { search, results } = useSearch();
     const { page, setPage, pageSize, pageCount, totalResults } = usePagination('search');
     const [query, setQuery] = React.useState('');
 

--- a/docs/pages/hooks/usesearch.mdx
+++ b/docs/pages/hooks/usesearch.mdx
@@ -1,5 +1,6 @@
 import SEO from '../../components/SEO';
 import { useState } from 'react';
+import { Select } from '@sajari/react-components';
 
 <SEO title="useSearch" description="useSearch provides a getter & setter for the current query." />
 
@@ -42,7 +43,7 @@ function Example() {
 function Example() {
   const [tabIndex, setTabIndex] = React.useState(0);
   const queries = ['phone', 'chair', 'macbook'];
-  const { results = [] } = useSearch(queries[tabIndex]);
+  const { results = [], loading } = useSearch(queries[tabIndex]);
 
   return (
     <>
@@ -53,7 +54,8 @@ function Example() {
           <Tab>Macbook</Tab>
         </TabList>
         <div>
-          {results.length > 0 && (
+          {loading && <p className="p-4">Searching...</p>}
+          {!loading && results.length > 0 && (
             <ul className="list-disc px-5 space-y-2 mt-5">
               {results.map(({ values: { title, id } }) => (
                 <li key={id}>{title}</li>
@@ -78,22 +80,40 @@ function Example() {
     },
     'website',
   );
-  const values = new Values({ q: 'api', resultsPerPage: 3 });
+  const values = new Values({ q: 'api', resultsPerPage: 1 });
   const fields = { title: 'name' };
 
-  const { results = [] } = useSearch(values, pipeline, fields);
+  const SearchPlayground = React.memo(() => {
+    const { results = [], loading } = useSearch({ values, pipeline, fields });
 
-  return (
-    <>
-      {results.length > 0 && (
-        <ul className="list-disc px-5 space-y-2">
-          {results.map(({ values: { title, id } }) => (
-            <li key={id}>{title}</li>
-          ))}
-        </ul>
-      )}
-    </>
-  );
+    return (
+      <div className="flex flex-col space-y-4">
+        <div className="flex space-x-3 items-center">
+          <p>PageSize</p>
+          <Select
+            onChange={(e) => {
+              values.set({ resultsPerPage: Number(e.target.value) });
+            }}
+          >
+            <option value="1">1</option>
+            <option value="3">3</option>
+          </Select>
+        </div>
+        <div>
+          {loading && <p>Searching...</p>}
+          {!loading && results.length > 0 && (
+            <ul className="list-disc px-5 space-y-2">
+              {results.map(({ values: { title } }) => (
+                <li key={title}>{title}</li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    );
+  });
+
+  return <SearchPlayground />;
 }
 ```
 
@@ -101,8 +121,11 @@ function Example() {
 
 `useSearch` returns an object containing the following properties:
 
-| Name           | Type       | Default | Description                            |
-| -------------- | ---------- | ------- | -------------------------------------- |
-| `results`      | `Result[]` |         | An array of results that met the query |
-| `latency`      | `number`   |         | The engine latency                     |
-| `totalResults` | `number`   |         | The total count of results             |
+| Name           | Type                   | Default | Description                                                                               |
+| -------------- | ---------------------- | ------- | ----------------------------------------------------------------------------------------- |
+| `results`      | `Result[]`             |         | An array of results that met the query                                                    |
+| `latency`      | `number`               |         | The engine latency                                                                        |
+| `totalResults` | `number`               |         | The total count of results                                                                |
+| `search`       | `(q?: string) => void` |         | The search method, call without param to resend the search request with the current query |
+| `loading`      | `boolean`              |         | Is a search request being processed                                                       |
+| `error`        | `Error` \| `null`      |         | The error encountered while searching                                                     |

--- a/docs/pages/hooks/usesorting.mdx
+++ b/docs/pages/hooks/usesorting.mdx
@@ -9,7 +9,7 @@ import SEO from '../../components/SEO';
 ```js
 import { Results } from '@sajari/react-search-ui';
 import { Select, Input } from '@sajari/react-components';
-import { useSorting, useSearchContext, SearchContextProvider, Pipeline, Values } from '@sajari/react-hooks';
+import { useSorting, useSearch, SearchContextProvider, Pipeline, Values } from '@sajari/react-hooks';
 ```
 
 ## Usage
@@ -36,15 +36,9 @@ function Example() {
   const values = new Values({ q: '' });
 
   const SearchPlayground = React.memo(() => {
-    const { search, results } = useSearchContext();
+    const { search, results } = useSearch();
     const { sorting, setSorting } = useSorting();
     const [query, setQuery] = React.useState('');
-
-    React.useEffect(() => {
-      if (query) {
-        search(query);
-      }
-    }, [sorting]);
 
     return (
       <div className="flex flex-col space-y-4">
@@ -56,7 +50,7 @@ function Example() {
               search(query);
             }}
           >
-            <Input label="Search something" onChange={(value) => setQuery(value)} />
+            <Input label="Search something" value={query} onChange={(value) => setQuery(value)} />
           </form>
           <div className="w-2/5">
             <Select value={sorting} onChange={(e) => setSorting(e.target.value)}>

--- a/docs/pages/search-ui/pagesize.mdx
+++ b/docs/pages/search-ui/pagesize.mdx
@@ -9,7 +9,7 @@ The PageSize component renders a select component for page sizes.
 ```js
 import { Results, PageSize } from '@sajari/react-search-ui';
 import { Select, Input } from '@sajari/react-components';
-import { usePageSize, useSearchContext, SearchContextProvider, Pipeline, Values } from '@sajari/react-hooks';
+import { usePageSize, useSearch, SearchContextProvider, Pipeline, Values } from '@sajari/react-hooks';
 ```
 
 ## Usage
@@ -28,7 +28,7 @@ function Example() {
   const values = new Values({ q: '' });
 
   const SearchPlayground = React.memo(() => {
-    const { search, results } = useSearchContext();
+    const { search, results } = useSearch();
     const { setPageSize } = usePageSize();
     const [query, setQuery] = React.useState('');
 
@@ -61,14 +61,9 @@ function Example() {
 }
 ```
 
-### Search on value change
-
-By default, the `PageSize` component will initiate search request whenever page size value changes, you can opt-out of that by passing `searchOnChange={false}` to `PageSize`, in that case you'll need to use the `usePageSize` hook to detect changes to `pageSize` value.
-
 ## Props
 
-| Name             | Type            | Default               | Description                                                  |
-| ---------------- | --------------- | --------------------- | ------------------------------------------------------------ |
-| `label`          | `string`        | `Size`                |                                                              |
-| `sizes`          | `Array<number>` | [10, 20, 35, 50, 100] |
-| `searchOnChange` | `boolean`       | `true`                | Whether to re-initiate search request when page size changes |
+| Name    | Type            | Default               | Description |
+| ------- | --------------- | --------------------- | ----------- |
+| `label` | `string`        | `Size`                |             |
+| `sizes` | `Array<number>` | [10, 20, 35, 50, 100] |

--- a/docs/pages/search-ui/pagination.mdx
+++ b/docs/pages/search-ui/pagination.mdx
@@ -8,7 +8,7 @@ The Pagination component renders a pagination component with config wired in.
 
 ```js
 import { Pagination } from '@sajari/react-search-ui';
-import { SearchContextProvider, useSearchContext } from '@sajari/react-hooks';
+import { SearchContextProvider, useSearch } from '@sajari/react-hooks';
 ```
 
 ## Usage
@@ -27,11 +27,7 @@ function Example() {
   const values = new Values({ q: '' });
 
   const SearchPlayground = React.memo(() => {
-    const { search } = useSearchContext();
-
-    React.useEffect(() => {
-      search('iphone');
-    }, []);
+    useSearch('iphone');
 
     return <Pagination />;
   });

--- a/docs/pages/search-ui/sorting.mdx
+++ b/docs/pages/search-ui/sorting.mdx
@@ -9,7 +9,7 @@ The Sorting component renders a select component for sorting options.
 ```js
 import { Results } from '@sajari/react-search-ui';
 import { Select, Input } from '@sajari/react-components';
-import { Sorting, useSearchContext, SearchContextProvider, Pipeline, Values } from '@sajari/react-hooks';
+import { Sorting, useSearch, SearchContextProvider, Pipeline, Values } from '@sajari/react-hooks';
 ```
 
 ## Usage
@@ -28,7 +28,7 @@ function Example() {
   const values = new Values({ q: '' });
 
   const SearchPlayground = React.memo(() => {
-    const { search, results } = useSearchContext();
+    const { search, results } = useSearch();
     const [query, setQuery] = React.useState('');
 
     return (
@@ -69,14 +69,9 @@ function Example() {
 }
 ```
 
-### Search on value change
-
-By default, the `Sorting` component will initiate search request whenever sorting value changes, you can opt-out of that by passing `searchOnChange={false}` to `Sorting`, in that case you'll need to use the `useSorting` hook to detect changes to `sorting` value.
-
 ## Props
 
-| Name             | Type                                   | Default                                | Description                                                |
-| ---------------- | -------------------------------------- | -------------------------------------- | ---------------------------------------------------------- |
-| `label`          | `string`                               | `"Sort"`                               |                                                            |
-| `options`        | `Array<{name: string, value: string}>` | `[{name: "Most relavant", value: ""}]` |                                                            |
-| `searchOnChange` | `boolean`                              | `true`                                 | Whether to re-initiate search request when sorting changes |
+| Name      | Type                                   | Default                                | Description |
+| --------- | -------------------------------------- | -------------------------------------- | ----------- |
+| `label`   | `string`                               | `"Sort"`                               |             |
+| `options` | `Array<{name: string, value: string}>` | `[{name: "Most relavant", value: ""}]` |             |

--- a/packages/hooks/src/SearchContextProvider/controllers/pipeline.ts
+++ b/packages/hooks/src/SearchContextProvider/controllers/pipeline.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 /* eslint-disable no-underscore-dangle */
-import { Client } from '@sajari/sdk-js';
+import { Client, RequestError } from '@sajari/sdk-js';
 
 import { EVENT_RESPONSE_UPDATED, EVENT_RESULT_CLICKED, EVENT_SEARCH_SENT } from '../events';
 import { Analytics, GoogleAnalytics } from './analytics';
@@ -149,8 +149,6 @@ export class Pipeline {
           new Map(Object.entries(response)),
           new Map(Object.entries(responseValues)),
         );
-
-        this._emitResponseUpdated(this.response);
       })
       .catch((error) => {
         console.error(error);
@@ -159,7 +157,10 @@ export class Pipeline {
           return;
         }
 
-        this.response = new Response(null, new Map(Object.entries(values)), undefined, undefined);
+        this.response = new Response(error, new Map(Object.entries(values)), undefined, undefined);
+      })
+      .finally(() => {
+        this._emitResponseUpdated(this.response);
       });
     this._emitSearchSent(values);
   }

--- a/packages/hooks/src/SearchContextProvider/index.tsx
+++ b/packages/hooks/src/SearchContextProvider/index.tsx
@@ -75,6 +75,7 @@ const SearchContextProvider: React.FC<SearchProviderValues> = ({
   instant: instantProp,
   searchOnLoad,
 }) => {
+  const [searching, setSearching] = useState(false);
   const [searchState, setSearchState] = useState(defaultState);
   const [instantState, setInstantState] = useState(defaultState);
   const instant = useRef(instantProp);
@@ -97,13 +98,14 @@ const SearchContextProvider: React.FC<SearchProviderValues> = ({
     const unregisterFunctions: UnlistenFn[] = [];
 
     unregisterFunctions.push(
-      search.pipeline.listen(EVENT_RESPONSE_UPDATED, (response: Response) =>
+      search.pipeline.listen(EVENT_RESPONSE_UPDATED, (response: Response) => {
+        setSearching(false);
         setSearchState((prevState) => ({
           ...prevState,
           response,
           ...responseUpdatedListener(search.values, prevState.config, response),
-        })),
-      ),
+        }));
+      }),
     );
 
     unregisterFunctions.push(
@@ -158,6 +160,7 @@ const SearchContextProvider: React.FC<SearchProviderValues> = ({
   const searchFn = useCallback(
     (key: 'search' | 'instant') =>
       debounce((query: string, override: boolean = false) => {
+        setSearching(true);
         const func = key === 'instant' ? instant.current : search;
         const state = key === 'instant' ? instantState : searchState;
         const { pipeline, values } = func as ProviderPipelineConfig;
@@ -214,6 +217,7 @@ const SearchContextProvider: React.FC<SearchProviderValues> = ({
         search: searchFn('search'),
         clear: clear('search'),
         fields: search.fields,
+        searching,
       },
       instant: {
         ...state.instant,

--- a/packages/hooks/src/SearchContextProvider/types.ts
+++ b/packages/hooks/src/SearchContextProvider/types.ts
@@ -17,6 +17,7 @@ export interface PipelineContextState {
   search: SearchFn;
   clear: ClearFn;
   fields?: FieldDictionary;
+  searching: boolean;
 }
 
 export interface ProviderPipelineConfig {

--- a/packages/hooks/src/useSearch/types.ts
+++ b/packages/hooks/src/useSearch/types.ts
@@ -1,0 +1,16 @@
+import { Result } from '@sajari/sdk-js';
+import { Pipeline, Values } from '../SearchContextProvider';
+import { Fields } from '../SearchContextProvider/types';
+
+export type UseSearchParams = string | UseSearchCustomConfig;
+
+export type UseSearchCustomConfig = { pipeline: Pipeline; values: Values; fields?: Record<string, string> & Fields };
+
+export interface UseSearchResult {
+  latency?: number;
+  totalResults?: number;
+  results?: Result[];
+  search: (q?: string) => void;
+  loading: boolean;
+  error: Error | null;
+}

--- a/packages/hooks/src/utils/debounce.ts
+++ b/packages/hooks/src/utils/debounce.ts
@@ -1,31 +1,31 @@
-export default function debounce<F extends (...args: any[]) => void>(
+import { useRef } from 'react';
+
+export default function useDebounce<F extends (...args: any[]) => void>(
   func: F,
   waitMilliseconds = 50,
   options = {
     isImmediate: false,
   },
 ): F {
-  let timeoutId: number | undefined;
+  const timeoutIdRef = useRef<ReturnType<typeof setTimeout>>();
 
   // eslint-disable-next-line func-names
   return function (this: any, ...args: any[]) {
+    if (timeoutIdRef.current) {
+      clearTimeout(timeoutIdRef.current);
+    }
     const context = this;
 
     const doLater = () => {
-      timeoutId = undefined;
+      timeoutIdRef.current = undefined;
       if (!options.isImmediate) {
         func.apply(context, args);
       }
     };
 
-    const shouldCallNow = options.isImmediate && timeoutId === undefined;
+    const shouldCallNow = options.isImmediate && timeoutIdRef.current === undefined;
 
-    if (timeoutId !== undefined) {
-      clearTimeout(timeoutId);
-    }
-
-    // @ts-ignore
-    timeoutId = setTimeout(doLater, waitMilliseconds);
+    timeoutIdRef.current = setTimeout(doLater, waitMilliseconds);
 
     if (shouldCallNow) {
       func.apply(context, args);

--- a/packages/search-ui/src/PageSize/index.tsx
+++ b/packages/search-ui/src/PageSize/index.tsx
@@ -3,8 +3,8 @@
 import { jsx } from '@emotion/core';
 import { useId } from '@reach/auto-id';
 import { Label, Select } from '@sajari/react-components';
-import { usePageSize, useQuery, useSearchContext } from '@sajari/react-hooks';
-import React, { useEffect } from 'react';
+import { usePageSize } from '@sajari/react-hooks';
+import React from 'react';
 import { __DEV__ } from 'sajari-react-sdk-utils';
 import tw from 'twin.macro';
 
@@ -12,17 +12,9 @@ import { PageSizeProps } from './types';
 
 const defaultSizes = [10, 20, 35, 50, 100];
 
-const PageSize: React.FC<PageSizeProps> = ({ searchOnChange = true, label = 'Show', sizes = defaultSizes }) => {
-  const { search } = useSearchContext();
+const PageSize: React.FC<PageSizeProps> = ({ label = 'Size', sizes = defaultSizes }) => {
   const { pageSize, setPageSize } = usePageSize();
-  const { query } = useQuery();
   const id = `page-size-${useId()}`;
-
-  useEffect(() => {
-    if (searchOnChange) {
-      search(query);
-    }
-  }, [pageSize]);
 
   return (
     <div css={tw`flex space-x-4`}>

--- a/packages/search-ui/src/PageSize/types.ts
+++ b/packages/search-ui/src/PageSize/types.ts
@@ -1,5 +1,4 @@
 export interface PageSizeProps {
   label?: string;
   sizes?: number[];
-  searchOnChange?: boolean;
 }

--- a/packages/search-ui/src/Sorting/index.tsx
+++ b/packages/search-ui/src/Sorting/index.tsx
@@ -3,8 +3,8 @@
 import { jsx } from '@emotion/core';
 import { useId } from '@reach/auto-id';
 import { Label, Select } from '@sajari/react-components';
-import { useQuery, useSearchContext, useSorting } from '@sajari/react-hooks';
-import React, { useEffect } from 'react';
+import { useSorting } from '@sajari/react-hooks';
+import React from 'react';
 import { __DEV__ } from 'sajari-react-sdk-utils';
 import tw from 'twin.macro';
 
@@ -12,17 +12,9 @@ import { SortingProps, SortOption } from './types';
 
 const defaultOptions: SortOption[] = [{ name: 'Most relavant', value: '' }];
 
-const Sorting: React.FC<SortingProps> = ({ searchOnChange = true, label = 'Sort', options = defaultOptions }) => {
-  const { search } = useSearchContext();
-  const { query } = useQuery();
+const Sorting: React.FC<SortingProps> = ({ label = 'Sort', options = defaultOptions }) => {
   const { sorting, setSorting } = useSorting();
   const id = `sorting-${useId()}`;
-
-  useEffect(() => {
-    if (searchOnChange) {
-      search(query);
-    }
-  }, [sorting]);
 
   return (
     <div css={tw`flex space-x-4`}>

--- a/packages/search-ui/src/Sorting/types.ts
+++ b/packages/search-ui/src/Sorting/types.ts
@@ -6,5 +6,4 @@ export type SortOption = {
 export interface SortingProps {
   label?: string;
   options?: SortOption[];
-  searchOnChange?: boolean;
 }


### PR DESCRIPTION
## What does this PR do?
Rewrite the `useSearch` to be able to search when the request object changes
- [x] Use `useSearch` instead of `useSearchContext` whenever possible
- [x] Add `loading`, `error` as return value of `useSearch`
- [x] Allow for query override via `useSearch` parameter
- [x] Allow for `Pipeline`, `Values`, `fields` override

It should be noted that when this PR is merged all hooks change will trigger search request