### PR TITLE
V3: fix: summary logic

### DIFF
--- a/packages/hooks/src/useSearchContext/index.ts
+++ b/packages/hooks/src/useSearchContext/index.ts
@@ -12,6 +12,7 @@ function useSearchContext<T = Record<string, string | string[]>>() {
   const reqResults = response?.getResults();
 
   return {
+    latency: response?.getTime(),
     page,
     pageSize,
     totalResults,

--- a/packages/search-ui/src/Summary/index.tsx
+++ b/packages/search-ui/src/Summary/index.tsx
@@ -1,10 +1,10 @@
 /* eslint-disable react/jsx-one-expression-per-line */
 import { Text } from '@sajari/react-components';
-import { useSearch } from '@sajari/react-hooks';
+import { useSearchContext } from '@sajari/react-hooks';
 import React, { HTMLAttributes } from 'react';
 
 const Summary = (props: HTMLAttributes<HTMLElement>) => {
-  const { latency, totalResults } = useSearch();
+  const { latency, totalResults } = useSearchContext();
 
   if (!totalResults) {
     return null;


### PR DESCRIPTION
## What this PR does

- [x] Replace `useSearch` with `useSearchContext` (the former fetches on mount - which is unnecessary and introduces a bug while being used in the bestbuy demo)