### PR TITLE
V3: fix: convert Swatch to be controlled input

### DIFF
--- a/packages/components/src/Swatch/color.tsx
+++ b/packages/components/src/Swatch/color.tsx
@@ -4,7 +4,7 @@ import { jsx } from '@emotion/core';
 import { useSwitch } from '@react-aria/switch';
 import { useToggleState } from '@react-stately/toggle';
 import ColorClass from 'color';
-import React from 'react';
+import React, { useCallback } from 'react';
 import { __DEV__ } from 'sajari-react-sdk-utils';
 import tw, { styled } from 'twin.macro';
 
@@ -53,22 +53,19 @@ export const Color = ({
 }: ColorProps) => {
   const ref = React.useRef<HTMLInputElement>(null);
   const { state, setState } = useSwatchContext();
-  const tempState = useToggleState({
-    isSelected: state.includes(id),
-    onChange: (isSelected) => {
-      const newState = isSelected ? [...state, id] : state.filter((i) => i !== id);
-      setState(newState);
-    },
-  });
-
+  const toggleState = useToggleState();
+  const checked = state.includes(id);
+  const toggle = useCallback(() => setState(checked ? state.filter((i) => i !== id) : [...state, id]), [
+    checked,
+    state,
+  ]);
   const { inputProps } = useSwitch(
     {
-      isSelected: tempState.isSelected,
-      value: String(tempState.isSelected),
+      value: String(checked),
       'aria-label': id,
       name: id,
     },
-    tempState,
+    toggleState,
     ref,
   );
 
@@ -79,8 +76,16 @@ export const Color = ({
       <Box as="span" css={tw`sr-only`}>
         {id}
       </Box>
-      <Box as="input" css={tw`sr-only`} {...inputProps} {...focusProps} ref={ref} />
-      <Check css={tempState.isSelected ? tw`opacity-100 fill-current` : tw`opacity-0 fill-current`} />
+      <Box
+        as="input"
+        css={tw`sr-only`}
+        {...inputProps}
+        {...focusProps}
+        ref={ref}
+        aria-checked={checked}
+        onClick={toggle}
+      />
+      <Check css={checked ? tw`opacity-100 fill-current` : tw`opacity-0 fill-current`} />
     </StyledLabel>
   );
 };
@@ -90,6 +95,7 @@ if (__DEV__) {
 }
 
 /** We're doing it manually rather a for loop because this enables code completion */
+
 Color.White = (overridingProps: ColorProps) => Color.call(null, { ...colors[0], ...overridingProps });
 
 Color.Silver = (overridingProps: ColorProps) => Color.call(null, { ...colors[1], ...overridingProps });

--- a/packages/hooks/src/SearchContextProvider/index.tsx
+++ b/packages/hooks/src/SearchContextProvider/index.tsx
@@ -3,6 +3,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { createContext } from 'sajari-react-sdk-utils';
 
+import { isEmpty } from '../utils/assertion';
 import debounce from '../utils/debounce';
 import { Config, defaultConfig } from './config';
 import {
@@ -205,9 +206,11 @@ const SearchContextProvider: React.FC<SearchProviderValues> = ({
         }
 
         variables.set(text);
-        if (text[config.qParam]) {
-          pipeline.search(variables.get());
+        const { filter } = variables.get();
+        if (isEmpty(filter)) {
+          variables.set({ filter: '_id != ""' });
         }
+        pipeline.search(variables.get());
       }, 50),
     [],
   );

--- a/packages/hooks/src/utils/assertion.ts
+++ b/packages/hooks/src/utils/assertion.ts
@@ -1,0 +1,34 @@
+/* eslint-disable no-underscore-dangle */
+/* eslint-disable @typescript-eslint/naming-convention */
+export function isArray<T>(value: any): value is T[] {
+  return Array.isArray(value);
+}
+
+export function isNumber(value: any): value is number {
+  return typeof value === 'number';
+}
+
+export const isEmptyArray = (value: any) => isArray(value) && value.length === 0;
+
+export const isObject = (value: any) => {
+  const type = typeof value;
+  return value != null && (type === 'object' || type === 'function') && !isArray(value);
+};
+
+export const isEmptyObject = (value: any) => isObject(value) && Object.keys(value).length === 0;
+
+// Empty assertions
+export const isEmpty = (value: any) => {
+  if (isArray(value)) {
+    return isEmptyArray(value);
+  }
+  if (isObject(value)) {
+    return isEmptyObject(value);
+  }
+  if (value == null || value === '') {
+    return true;
+  }
+  return false;
+};
+
+export const __DEV__ = process.env.NODE_ENV !== 'production';


### PR DESCRIPTION
## What this PR does
- [x] Turn `Swatch` to be controlled element because Preact doesn't handle uncontrolled element very well