### PR TITLE
V3: fix: search on empty string with custom filter

### DIFF
--- a/packages/hooks/src/SearchContextProvider/index.tsx
+++ b/packages/hooks/src/SearchContextProvider/index.tsx
@@ -3,6 +3,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { createContext } from 'sajari-react-sdk-utils';
 
+import { isEmpty } from '../utils/assertion';
 import debounce from '../utils/debounce';
 import { Config, defaultConfig } from './config';
 import {
@@ -205,9 +206,11 @@ const SearchContextProvider: React.FC<SearchProviderValues> = ({
         }
 
         variables.set(text);
-        if (text[config.qParam]) {
-          pipeline.search(variables.get());
+        const { filter } = variables.get();
+        if (isEmpty(filter)) {
+          variables.set({ filter: '_id != ""' });
         }
+        pipeline.search(variables.get());
       }, 50),
     [],
   );

--- a/packages/hooks/src/utils/assertion.ts
+++ b/packages/hooks/src/utils/assertion.ts
@@ -1,0 +1,34 @@
+/* eslint-disable no-underscore-dangle */
+/* eslint-disable @typescript-eslint/naming-convention */
+export function isArray<T>(value: any): value is T[] {
+  return Array.isArray(value);
+}
+
+export function isNumber(value: any): value is number {
+  return typeof value === 'number';
+}
+
+export const isEmptyArray = (value: any) => isArray(value) && value.length === 0;
+
+export const isObject = (value: any) => {
+  const type = typeof value;
+  return value != null && (type === 'object' || type === 'function') && !isArray(value);
+};
+
+export const isEmptyObject = (value: any) => isObject(value) && Object.keys(value).length === 0;
+
+// Empty assertions
+export const isEmpty = (value: any) => {
+  if (isArray(value)) {
+    return isEmptyArray(value);
+  }
+  if (isObject(value)) {
+    return isEmptyObject(value);
+  }
+  if (value == null || value === '') {
+    return true;
+  }
+  return false;
+};
+
+export const __DEV__ = process.env.NODE_ENV !== 'production';


### PR DESCRIPTION
## What this PR does
- [x] Allow search on empty query
- [x] Add custom filter `_id != ""`