### PR TITLE
fix: twTheme warning

### DIFF
--- a/packages/components/src/Swatch/color.tsx
+++ b/packages/components/src/Swatch/color.tsx
@@ -69,7 +69,7 @@ export const Color = ({
     ref,
   );
 
-  const { focusProps, focusRingStyles } = useFocusRingStyles({ color: border });
+  const { focusProps, focusRingStyles } = useFocusRingStyles({ color: border.toString() });
 
   return (
     <StyledLabel bg={bg} border={border} textColor={color} rounded={rounded} css={focusRingStyles}>

--- a/packages/components/src/hooks/useRingStyles.ts
+++ b/packages/components/src/hooks/useRingStyles.ts
@@ -19,9 +19,9 @@ export default function useRingStyles(props?: UseRingStylesProps) {
     let borderColor = color;
 
     if (disabled) {
-      borderColor = twTheme`colors.gray.500`;
+      borderColor = twTheme`colors.gray.500`.toString();
     } else if (invalid) {
-      borderColor = twTheme`colors.red.500`;
+      borderColor = twTheme`colors.red.500`.toString();
     }
 
     let borderRadius;

--- a/packages/styles/src/styled/theming.tsx
+++ b/packages/styles/src/styled/theming.tsx
@@ -23,9 +23,9 @@ export interface Theme {
 const defaultTheme: Theme = {
   color: {
     primary: {
-      base: twTheme`colors.indigo.500`,
-      text: twTheme`colors.white`,
-      active: twTheme`colors.indigo.600`,
+      base: twTheme`colors.indigo.500`.toString(),
+      text: twTheme`colors.white`.toString(),
+      active: twTheme`colors.indigo.600`.toString(),
     },
   },
 };


### PR DESCRIPTION
Casting `ThemeFn` to `string`, otherwise, it gives the warning causing build failed.

![image](https://user-images.githubusercontent.com/12707960/98913975-a98dd280-24fa-11eb-8a7e-69f5f3fb189e.png)
