### PR TITLE
V3: fix: utils - specify emotion as deps instead of devdeps

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -21,22 +21,19 @@
     "dist"
   ],
   "peerDependencies": {
-    "@emotion/core": "> 10",
-    "@emotion/styled": "> 10",
     "@tailwindcss/ui": "^0.6.2",
-    "emotion-theming": "> 10",
     "react": "^16.8.0"
   },
   "devDependencies": {
-    "@emotion/core": "^10.1.0",
-    "@emotion/styled": "^10.0.27",
-    "emotion-theming": "^10.0.27",
     "tailwindcss": "^1.9.6",
     "tailwindcss-filters": "^3.0.0",
     "tailwindcss-truncate-multiline": "^1.0.3"
   },
   "dependencies": {
-    "tslib": "^2.0.3"
+    "tslib": "^2.0.3",
+    "@emotion/core": "^10.1.0",
+    "@emotion/styled": "^10.0.27",
+    "emotion-theming": "^10.0.27"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## What this PR does
- [x] Specify `emotion` to be included automatically in the build

@sampotts All the `1.0.0-alpha.1` packages work great, the fresh CRA is able to compile normally.
Just need this PR sorted out so that I won't have to manually add `@emotion/core` and etc when installing `@sajari/react-components` (which uses `utils` internally)