### PR TITLE
V3: chore: tidy up search logic

### DIFF
--- a/docs/pages/hooks/usepagesize.mdx
+++ b/docs/pages/hooks/usepagesize.mdx
@@ -30,20 +30,14 @@ function Example() {
   const SearchPlayground = React.memo(() => {
     const { search, results } = useSearch();
     const { pageSize, setPageSize } = usePageSize();
-    const [query, setQuery] = React.useState('');
+    const { query } = useQuery();
 
     return (
       <div className="flex flex-col space-y-4">
         <div className="flex space-x-4">
-          <form
-            className="w-3/5"
-            onSubmit={(e) => {
-              e.preventDefault();
-              search(query);
-            }}
-          >
-            <Input label="Search something" value={query} onChange={(value) => setQuery(value)} />
-          </form>
+          <div className="w-3/5">
+            <Input label="Search something" value={query} onChange={(value) => search(value)} />
+          </div>
           <div className="w-2/5">
             <Select value={`${pageSize}`} onChange={(e) => setPageSize(parseInt(e.target.value), 10)}>
               <option value="3">3</option>

--- a/docs/pages/hooks/usepagination.mdx
+++ b/docs/pages/hooks/usepagination.mdx
@@ -33,18 +33,13 @@ function Example() {
   const SearchPlayground = React.memo(() => {
     const { search, results } = useSearch();
     const { page, setPage, pageSize, pageCount, totalResults } = usePagination('search');
-    const [query, setQuery] = React.useState('');
+    const { query } = useQuery();
 
     return (
       <div className="flex flex-col space-y-4">
-        <form
-          onSubmit={(e) => {
-            e.preventDefault();
-            search(query);
-          }}
-        >
-          <Input label="Search something" value={query} onChange={(value) => setQuery(value)} />
-        </form>
+        <div>
+          <Input label="Search something" value={query} onChange={(value) => search(value)} />
+        </div>
         {results ? (
           <div className="flex flex-col space-y-6 items-center">
             <Results />

--- a/docs/pages/hooks/usesorting.mdx
+++ b/docs/pages/hooks/usesorting.mdx
@@ -38,20 +38,14 @@ function Example() {
   const SearchPlayground = React.memo(() => {
     const { search, results } = useSearch();
     const { sorting, setSorting } = useSorting();
-    const [query, setQuery] = React.useState('');
+    const { query } = useQuery();
 
     return (
       <div className="flex flex-col space-y-4">
         <div className="flex space-x-4">
-          <form
-            className="w-3/5"
-            onSubmit={(e) => {
-              e.preventDefault();
-              search(query);
-            }}
-          >
-            <Input label="Search something" value={query} onChange={(value) => setQuery(value)} />
-          </form>
+          <div className="w-3/5">
+            <Input label="Search something" value={query} onChange={(value) => search(value)} />
+          </div>
           <div className="w-2/5">
             <Select value={sorting} onChange={(e) => setSorting(e.target.value)}>
               <option value="">Most relavant</option>

--- a/docs/pages/search-ui/pagesize.mdx
+++ b/docs/pages/search-ui/pagesize.mdx
@@ -30,7 +30,7 @@ function Example() {
   const SearchPlayground = React.memo(() => {
     const { search, results } = useSearch();
     const { setPageSize } = usePageSize();
-    const [query, setQuery] = React.useState('');
+    const { query } = useQuery();
 
     return (
       <div className="flex flex-col space-y-4">
@@ -38,15 +38,9 @@ function Example() {
           <div className="w-1/5">
             <PageSize />
           </div>
-          <form
-            className="flex-1"
-            onSubmit={(e) => {
-              e.preventDefault();
-              search(query);
-            }}
-          >
-            <Input label="Search something" onChange={(value) => setQuery(value)} />
-          </form>
+          <div className="flex-1">
+            <Input label="Search something" value={query} onChange={(value) => search(value)} />
+          </div>
         </div>
         {results ? <Results /> : null}
       </div>

--- a/docs/pages/search-ui/sorting.mdx
+++ b/docs/pages/search-ui/sorting.mdx
@@ -29,7 +29,7 @@ function Example() {
 
   const SearchPlayground = React.memo(() => {
     const { search, results } = useSearch();
-    const [query, setQuery] = React.useState('');
+    const { query } = useQuery();
 
     return (
       <div className="flex flex-col space-y-4">
@@ -46,15 +46,9 @@ function Example() {
               ]}
             />
           </div>
-          <form
-            className="w-3/5"
-            onSubmit={(e) => {
-              e.preventDefault();
-              search(query);
-            }}
-          >
-            <Input label="Search something" onChange={(value) => setQuery(value)} />
-          </form>
+          <div className="w-3/5">
+            <Input label="Search something" value={query} onChange={(value) => search(value)} />
+          </div>
         </div>
         {results ? <Results /> : null}
       </div>

--- a/docs/pages/tracking/clicktracking.mdx
+++ b/docs/pages/tracking/clicktracking.mdx
@@ -33,18 +33,13 @@ function Example() {
 
   const SearchPlayground = React.memo(() => {
     const { search, results } = useSearch();
-    const [query, setQuery] = React.useState('');
+    const { query } = useQuery();
 
     return (
       <div className="flex flex-col space-y-4">
-        <form
-          onSubmit={(e) => {
-            e.preventDefault();
-            search(query);
-          }}
-        >
-          <Input label="Search something" value={query} onChange={(value) => setQuery(value)} />
-        </form>
+        <div>
+          <Input label="Search something" value={query} onChange={(value) => search(value)} />
+        </div>
         {results ? <Results /> : null}
       </div>
     );

--- a/docs/pages/tracking/notracking.mdx
+++ b/docs/pages/tracking/notracking.mdx
@@ -29,18 +29,13 @@ function Example() {
 
   const SearchPlayground = React.memo(() => {
     const { search, results } = useSearch();
-    const [query, setQuery] = React.useState('');
+    const { query } = useQuery();
 
     return (
       <div className="flex flex-col space-y-4">
-        <form
-          onSubmit={(e) => {
-            e.preventDefault();
-            search(query);
-          }}
-        >
-          <Input label="Search something" value={query} onChange={(value) => setQuery(value)} />
-        </form>
+        <div>
+          <Input label="Search something" value={query} onChange={(value) => search(value)} />
+        </div>
         {results ? <Results /> : null}
       </div>
     );

--- a/docs/pages/tracking/posnegtracking.mdx
+++ b/docs/pages/tracking/posnegtracking.mdx
@@ -33,18 +33,13 @@ function Example() {
   const SearchPlayground = React.memo(() => {
     const { search, results } = useSearch();
     const { consumeInteractionToken } = useTracking();
-    const [query, setQuery] = React.useState('');
+    const { query } = useQuery();
 
     return (
       <div className="flex flex-col space-y-4">
-        <form
-          onSubmit={(e) => {
-            e.preventDefault();
-            search(query);
-          }}
-        >
-          <Input label="Search something" value={query} onChange={(value) => setQuery(value)} />
-        </form>
+        <div>
+          <Input label="Search something" value={query} onChange={(value) => search(value)} />
+        </div>
         {results ? (
           <ul className="flex flex-col space-y-8 list-disc px-6">
             {results.map(({ values: { title }, token }) => {

--- a/packages/hooks/src/SearchContextProvider/index.tsx
+++ b/packages/hooks/src/SearchContextProvider/index.tsx
@@ -189,7 +189,7 @@ const SearchContextProvider: React.FC<SearchProviderValues> = ({
 
   const searchFn = useCallback(
     (key: 'search' | 'instant') =>
-      debounce((query: string, override: boolean = false) => {
+      debounce((inputQuery?: string, override: boolean = false) => {
         if (!searching) {
           setSearching(true);
         }
@@ -199,7 +199,7 @@ const SearchContextProvider: React.FC<SearchProviderValues> = ({
         const { config } = state;
 
         const text = {
-          [config.qParam]: query,
+          [config.qParam]: inputQuery ?? searchState.query,
           [config.qOverrideParam]: undefined,
         };
 
@@ -214,7 +214,7 @@ const SearchContextProvider: React.FC<SearchProviderValues> = ({
         }
         pipeline.search(variables.get());
       }, 50),
-    [],
+    [searchState.query],
   );
 
   const clear = useCallback(

--- a/packages/hooks/src/SearchContextProvider/types.ts
+++ b/packages/hooks/src/SearchContextProvider/types.ts
@@ -1,7 +1,7 @@
 import { Config } from './config';
 import { Filter, Pipeline, Response, Variables } from './controllers';
 
-export type SearchFn = (query: string, override?: boolean) => void;
+export type SearchFn = (query?: string, override?: boolean) => void;
 export type ClearFn = (variables?: { [k: string]: string | undefined }) => void;
 export type ResultClickedFn = (url: string) => void;
 export type PaginateFn = (page: number) => void;

--- a/packages/hooks/src/usePageSize/index.ts
+++ b/packages/hooks/src/usePageSize/index.ts
@@ -6,6 +6,7 @@ import { UsePageSizeResult } from './types';
 function usePageSize(): UsePageSizeResult {
   const {
     search: {
+      search,
       config: { resultsPerPageParam },
       variables,
     },
@@ -14,8 +15,9 @@ function usePageSize(): UsePageSizeResult {
   const setPageSize = React.useCallback(
     (size: number) => {
       variables.set({ [resultsPerPageParam]: size });
+      search();
     },
-    [variables],
+    [variables, search],
   );
 
   const pageSize = parseInt(variables.get()[resultsPerPageParam], 10);

--- a/packages/hooks/src/useQuery/index.ts
+++ b/packages/hooks/src/useQuery/index.ts
@@ -4,12 +4,16 @@ import { useContext } from '../SearchContextProvider';
 
 function useQuery() {
   const {
-    search: { variables, query },
+    search: { search, variables, query },
   } = useContext();
 
-  const setQuery = useCallback((q: string) => {
-    variables.set({ q });
-  }, []);
+  const setQuery = useCallback(
+    (q: string) => {
+      variables.set({ q });
+      search(q);
+    },
+    [search, variables],
+  );
 
   return { query, setQuery };
 }

--- a/packages/hooks/src/useSearch/index.ts
+++ b/packages/hooks/src/useSearch/index.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-shadow */
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { useContext } from '../SearchContextProvider';
 import { defaultConfig } from '../SearchContextProvider/config';
@@ -52,18 +52,12 @@ function useCustomSearch({ pipeline, variables, fields = {} }: UseSearchCustomCo
 
 function useNormalSearch(queryOverride: string = ''): UseSearchResult {
   const [error, setError] = useState<Error | null>(null);
-  const firstRender = useRef(true);
   const { query } = useQuery();
   const {
-    search: { searching, response, fields = {}, variables, search: searchFn, config },
+    search: { searching, response, fields = {}, search: searchFn },
   } = useContext();
 
   const results = response?.getResults();
-
-  const request = {
-    ...variables.get(),
-    [config.pageParam]: undefined, // Exclude this from being in JSON.stringify to prevent the search being called twice
-  };
 
   const search = useCallback(
     (q?: string) => {
@@ -79,14 +73,6 @@ function useNormalSearch(queryOverride: string = ''): UseSearchResult {
   useEffect(() => {
     searchFn(queryOverride);
   }, [queryOverride]);
-
-  useEffect(() => {
-    if (firstRender.current) {
-      firstRender.current = false;
-      return;
-    }
-    search();
-  }, [JSON.stringify(request)]);
 
   useEffect(() => {
     if (response) {

--- a/packages/hooks/src/useSorting/index.ts
+++ b/packages/hooks/src/useSorting/index.ts
@@ -5,10 +5,16 @@ import { UseSortingResult } from './types';
 
 function useSorting(): UseSortingResult {
   const {
-    search: { variables },
+    search: { search, variables },
   } = useContext();
 
-  const setSorting = useCallback((order: string) => variables.set({ sort: order }), [variables]);
+  const setSorting = useCallback(
+    (order: string) => {
+      variables.set({ sort: order });
+      search();
+    },
+    [variables],
+  );
 
   return {
     sorting: variables.get().sort ?? '',


### PR DESCRIPTION
## Why this PR exists
Currently, when we select any filter option, 2 requests are sent, 1 is from the `"selection-updated"` event handler that directly invokes the search function, and 2 is from `useSearch`'s logic of running effect whenever the value object changes.

This case isn't ideal and there is a potential of a loop occurring, the search function sets the values object -> which are picked up by `useEffect` -> which again runs the search function

## What this PR does
- [x] Remove the effect logic in `useSearch` entirely, so now all is handed to the search function
- [x] As a result, all hooks and composition that depends on that (`usePageSize`/`PageSize`, ...etc) must have an additional call to search function to preserve the reactivity
- [x] Some section of the docs are also updated to instant search instead of having to press enter - which isn't intuitive given the example's UI

## Result
Before the change, `useFilter` section of the docs when rendered will fire more than 3 requests which doesn't add up with the number of examples, and choosing any filter fires 2 requests as said above
After the change, only 3 requests are fired on mount, and only 1 request for each action after (input, filter)

@sampotts if you can please do a sanity check again in your local before merging to prevent any bugs, cheers :)