### PR TITLE
v3: feat: updated props for Filter component

### DIFF
--- a/docs/pages/hooks/usefilter.mdx
+++ b/docs/pages/hooks/usefilter.mdx
@@ -252,17 +252,13 @@ function Example() {
 
   const colorFilter = new Filter({
     name: 'color',
-    count: true,
     field: 'imageTags',
-    multi: true,
-    repeated: true,
+    array: true,
   });
 
   const ratingFilter = new Filter({
     name: 'rating',
-    count: true,
     field: 'rating',
-    multi: true,
   });
 
   const variables = new Variables({ q: '' });

--- a/docs/pages/search-ui/filter.mdx
+++ b/docs/pages/search-ui/filter.mdx
@@ -33,7 +33,6 @@ function Example() {
       HP: "brand = 'HP'",
       Garmin: "brand = 'Garmin'",
     },
-    multi: true,
   });
 
   const priceFilter = new FilterOptions({
@@ -99,15 +98,11 @@ function Example() {
   const categoryFilter = new FilterOptions({
     name: 'category',
     field: 'level1',
-    count: true,
-    multi: true,
   });
 
   const priceRangeFilter = new FilterOptions({
     name: 'priceRange',
-    count: true,
     field: 'price_range',
-    multi: true,
   });
 
   const variables = new Variables({ q: '' });
@@ -161,9 +156,7 @@ function Example() {
 
   const ratingFilter = new FilterOptions({
     name: 'rating',
-    count: true,
     field: 'rating',
-    multi: true,
   });
 
   const variables = new Variables({ q: '' });
@@ -221,10 +214,8 @@ function Example() {
 
   const colorFilter = new FilterOptions({
     name: 'color',
-    count: true,
     field: 'imageTags',
-    multi: true,
-    repeated: true,
+    array: true,
   });
 
   const variables = new Variables({ q: '' });
@@ -274,9 +265,11 @@ function Example() {
 
 Exclusive props if `type` is `list`.
 
-| Name         | Type                                | Default | Description                                                                              |
-| ------------ | ----------------------------------- | ------- | ---------------------------------------------------------------------------------------- |
-| `limit`      | `number`                            | `8`     | Maxium of shown items when the list is collapsed                                         |
-| `searchable` | `boolean`                           | `false` | If true, display an input for searching through filter items                             |
-| `sortable`   | `boolean`                           | `false` | If true, sort selected items on top                                                      |
-| `renderItem` | `(value:string) => React.ReactNode` | -       | A render prop function is used to custom the item label rather than just displaying text |
+| Name            | Type                                | Default                           | Description                                                                               |
+| --------------- | ----------------------------------- | --------------------------------- | ----------------------------------------------------------------------------------------- |
+| `limit`         | `number`                            | `8`                               | Maxium of shown items when the list is collapsed.                                         |
+| `searchable`    | `boolean`                           | `false`                           | If true, display an input for searching through filter items.                             |
+| `sort`          | `'count'` \| `'alpha'` \| `'none'`  | `'count'`                         | How to sort the filter items.                                                             |
+| `sortAscending` | `boolean`                           | `true` if `sort` is not `'count'` | Whether to sort in ascending order.                                                       |
+| `pinSelected`   | `boolean`                           | `true`                            | Pin selected items to the top of the list.                                                |
+| `renderItem`    | `(value:string) => React.ReactNode` | -                                 | A render prop function is used to custom the item label rather than just displaying text. |

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "tailwindcss": "^1.9.6",
-    "twin.macro": "^1.12.0"
+    "twin.macro": "^1.12.1"
   },
   "dependencies": {
     "@reach/auto-id": "^0.11.2",

--- a/packages/hooks/src/SearchContextProvider/controllers/filters/Filter.ts
+++ b/packages/hooks/src/SearchContextProvider/controllers/filters/Filter.ts
@@ -23,7 +23,7 @@ export default class Filter {
 
   private count: boolean;
 
-  private repeated: boolean;
+  private array: boolean;
 
   private joinOperator: JoinOperator;
 
@@ -38,12 +38,12 @@ export default class Filter {
   constructor({
     initial = [],
     joinOperator = 'OR',
-    multi = false,
+    multi = true,
     options = {},
-    repeated = false,
+    array = false,
     name,
     field,
-    count = false,
+    count = true,
   }: FilterOptions) {
     if (typeof initial === 'string') {
       initial = [initial];
@@ -64,7 +64,7 @@ export default class Filter {
     /** @private */
     this.multi = multi;
     /** @private */
-    this.repeated = repeated;
+    this.array = array;
     /** @private */
     this.joinOperator = joinOperator;
     /** @private */
@@ -146,8 +146,8 @@ export default class Filter {
     return this.current;
   }
 
-  public isRepeated() {
-    return this.repeated;
+  public isArray() {
+    return this.array;
   }
 
   public isMulti() {

--- a/packages/hooks/src/SearchContextProvider/controllers/filters/types.ts
+++ b/packages/hooks/src/SearchContextProvider/controllers/filters/types.ts
@@ -14,7 +14,7 @@ export interface FilterOptions {
   /** A field in schema, used if count = true */
   field?: string;
   /** Whether the response of the field is an array. This setting is only applicable if count is set */
-  repeated?: boolean;
+  array?: boolean;
   /** Multiple selections allowed */
   multi?: boolean;
   /** Join operator used if multi = true */

--- a/packages/hooks/src/useFilter/index.ts
+++ b/packages/hooks/src/useFilter/index.ts
@@ -44,7 +44,7 @@ function useFilter(name: string) {
     const fieldCount = filter.getField();
 
     if (isCount && fieldCount) {
-      const repeated = filter.isRepeated();
+      const array = filter.isArray();
       let count = {};
       ({ count } = (aggregateFilters || {})[fieldCount] || {});
       if (!count) {
@@ -55,7 +55,7 @@ function useFilter(name: string) {
       output = Object.entries(count).map(([label, count]: [string, number]) => ({
         label,
         count,
-        value: repeated ? `${fieldCount} ~ ['${label}']` : `${fieldCount} = '${label}'`,
+        value: array ? `${fieldCount} ~ ['${label}']` : `${fieldCount} = '${label}'`,
       }));
 
       filter.setOptions(output.reduce((a, c) => ({ ...a, [c.label]: c.value }), {}));

--- a/packages/search-ui/src/Filter/ListFilter.tsx
+++ b/packages/search-ui/src/Filter/ListFilter.tsx
@@ -9,7 +9,7 @@ import { IconSmallChevronDown, IconSmallChevronUp } from '../assets/icons';
 import Input from '../Input';
 import Box from './Box';
 import { ListFilterProps } from './types';
-import { sortList } from './utils';
+import { pinItems, sortItems } from './utils';
 
 const noop = () => {};
 
@@ -18,7 +18,9 @@ const ListFilter = ({
   title,
   limit = 8,
   searchable = false,
-  sortable = false,
+  pinSelected = true,
+  sort = 'count',
+  sortAscending = sort !== 'count',
   itemRender,
 }: Omit<ListFilterProps, 'type'>) => {
   const [query, setQuery] = useState('');
@@ -38,18 +40,18 @@ const ListFilter = ({
 
   const Control = multi ? Checkbox : Radio;
   const filtered = searchable ? options.filter((o) => o.label.toLowerCase().includes(query.toLowerCase())) : options;
-  const len = filtered.length;
-  const slice = len > limit;
-  const sorted = sortable ? sortList(filtered, false, 'count', 'label', selected) : filtered;
-  const sliced = slice && !expanded ? sorted.slice(0, limit) : sorted;
+  const slice = filtered.length > limit;
+  const sorted = sort !== 'none' ? sortItems(filtered, sort === 'count' ? 'count' : 'label', sortAscending) : filtered;
+  const ordered = pinSelected ? pinItems(sorted, selected, 'label') : sorted;
+  const sliced = slice && !expanded ? ordered.slice(0, limit) : ordered;
   const Icon = expanded ? IconSmallChevronUp : IconSmallChevronDown;
 
   const innerList = sliced.map(({ label, count }) => (
-    <div className="flex items-center justify-between" key={label + count}>
+    <div css={tw`flex items-center justify-between`} key={label + count}>
       <Control value={label} checked={selected.includes(label)} onChange={noop} css={tw`text-sm`}>
         {typeof itemRender === 'function' ? itemRender(label) : label}
       </Control>
-      <span className="ml-2 text-xs text-gray-400">{count}</span>
+      <span css={tw`ml-2 text-xs text-gray-400`}>{count}</span>
     </div>
   ));
 
@@ -88,7 +90,7 @@ const ListFilter = ({
             size="sm"
             spacing="none"
           >
-            {expanded ? 'Show less' : `Show ${len - limit} more`}
+            {expanded ? 'Show less' : `Show ${filtered.length - limit} more`}
             <Icon css={[tw`ml-2`, `color: ${({ theme }) => theme.colors.primary}`]} />
           </Button>
         </div>

--- a/packages/search-ui/src/Filter/types.ts
+++ b/packages/search-ui/src/Filter/types.ts
@@ -18,12 +18,16 @@ interface BaseFilterProps {
 export interface ListFilterProps extends BaseFilterProps {
   type: 'list';
   itemRender?: (value: string) => React.ReactNode;
-  // Maxium of shown items when the list is collapsed
+  /** Maxium of shown items when the list is collapsed */
   limit?: number;
-  // If true, display an input for searching through filter items
+  /** If true, display an input for searching through filter items */
   searchable?: boolean;
-  // If true, sort selected items on top
-  sortable?: boolean;
+  /** If true, sort selected items on top */
+  pinSelected?: boolean;
+  /** How to sort the items in the list */
+  sort?: 'count' | 'alpha' | 'none';
+  /** Sort in ascending order */
+  sortAscending?: boolean;
 }
 
 export interface ColorFilterProps extends BaseFilterProps {

--- a/packages/search-ui/src/Filter/utils.ts
+++ b/packages/search-ui/src/Filter/utils.ts
@@ -2,27 +2,22 @@
  * Sort an array based on a property of child item
  * @param {Array} list
  * @param {Boolean} asc - Ascending order?
- * @param {String} prop - Child item property to sort on
- * @param {String} pinKey - Property of object to get comparation in pinned array
- * @param {Array} pinned - Pin some items to the top (handy for checkbox lists where you may want to pin selected to the top)
+ * @param {String} prop - Property of child object to sort on
  */
-export function sortList(
-  list: Record<string, any>[],
-  asc: boolean = true,
-  prop: string,
-  pinKey: string,
-  pinned: string[] = [],
-) {
-  const sortedList = [...list];
+export function sortItems(list: Record<string, any>[], prop?: string, asc: boolean = true) {
+  return [...list].sort((a, b) => {
+    const l = prop ? a[prop] : a;
+    const r = prop ? b[prop] : b;
+    return asc ? l - r : r - l;
+  });
+}
 
-  sortedList
-    .sort((a, b) => {
-      const l = a[prop];
-      const r = b[prop];
-
-      return asc ? l - r : r - l;
-    })
-    .sort((a, b) => pinned.indexOf(b[pinKey]) - pinned.indexOf(a[pinKey]));
-
-  return sortedList;
+/**
+ * Pin items in an array to the start
+ * @param {Array} list
+ * @param {String} pinned - Items to pin in the array
+ * @param {String} prop - Property of child object to get comparation in pinned array
+ */
+export function pinItems(list: Record<string, any>[], pinned: string[] = [], prop: string) {
+  return [...list].sort((a, b) => pinned.indexOf(b[prop]) - pinned.indexOf(a[prop]));
 }


### PR DESCRIPTION
This change adds several props to the `Filter` component: 

- `sort` which allows choosing how the filter is sorted (`'count'` (by the numeric count), `'alpha'` (using the label) or `'none'` (random order))
- `sortAscending` - default `true` if sort is not `'count'`
- `pinSelected` - pin selected options to the top of the list - default `true` 

It changes `multi` and `count` to true in the `Filter` Class by default since I think this would be the most common use-case. 

It also renames `repeated` to `array` to match the latest API naming changes. 