### PR TITLE
V3: chore: add query overriding feature to Summary

### DIFF
--- a/docs/components/components.ts
+++ b/docs/components/components.ts
@@ -33,6 +33,7 @@ const hooks = [
   'useQuery',
   'useSearch',
   'useSorting',
+  'useAutocomplete',
   'useTracking',
   'useVariables',
 ].sort();

--- a/docs/pages/hooks/useautocomplete.mdx
+++ b/docs/pages/hooks/useautocomplete.mdx
@@ -1,0 +1,89 @@
+import SEO from '../../components/SEO';
+import { useState } from 'react';
+import { Select } from '@sajari/react-components';
+
+<SEO title="useAutocomplete" description="useAutocomplete provides result and method for the autocomplete pipeline." />
+
+# useAutocomplete
+
+`useAutocomplete` provides result and method for the autocomplete pipeline.
+
+```js
+import { useAutocomplete } from '@sajari/react-hooks';
+```
+
+## Usage
+
+```jsx
+function Example() {
+  const { search, results } = useSearch();
+  const { suggestions, search: searchInstant } = useAutocomplete();
+  const [query, setQuery] = React.useState('');
+
+  return (
+    <div className="flex flex-col space-y-3">
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          const formData = new FormData(e.target);
+          search(formData.get('query'));
+        }}
+      >
+        <Combobox
+          mode="suggestions"
+          name="query"
+          label="Query"
+          value={query}
+          items={suggestions}
+          onChange={(value) => {
+            setQuery(value);
+            searchInstant(value);
+          }}
+        />
+      </form>
+      {results && <Results />}
+    </div>
+  );
+}
+```
+
+### Autocomplete
+
+```jsx
+function Example() {
+  const { query } = useQuery();
+  const { search } = useSearch();
+  const { completion, search: searchInstant } = useAutocomplete();
+
+  return (
+    <div className="flex flex-col space-y-3">
+      <Combobox
+        value={query}
+        onChange={(value) => {
+          search(value);
+          searchInstant(value);
+        }}
+      />
+      {completion && query.trim() !== completion && (
+        <Text>
+          Search for{' '}
+          <Button spacing="none" appearance="link" onClick={() => search(completion)}>
+            {completion}
+          </Button>{' '}
+          instead of &quot;<strong>{query}</strong>&quot;
+        </Text>
+      )}
+    </div>
+  );
+}
+```
+
+## Anatomy
+
+`useAutocomplete` returns an object containing the following properties:
+
+| Name          | Type                   | Default | Description                                                          |
+| ------------- | ---------------------- | ------- | -------------------------------------------------------------------- |
+| `suggestions` | `string[]`             |         | An array of suggestions for the query                                |
+| `completion`  | `string`               |         | A string that is predicted by the pipeline base on the current query |
+| `search`      | `(q?: string) => void` |         | Function used to search for suggestions                              |

--- a/docs/pages/search-ui/summary.mdx
+++ b/docs/pages/search-ui/summary.mdx
@@ -22,3 +22,47 @@ function Example() {
   return <Summary />;
 }
 ```
+
+### Override a query via autocomplete
+
+```jsx
+function Example() {
+  const { search, searchInstant } = useSearch();
+  const { query } = useQuery();
+
+  return (
+    <div className="flex flex-col space-y-3">
+      <Input
+        value={query}
+        onChange={(v) => {
+          search(v);
+          searchInstant(v); // Triggers autocomplete pipeline
+        }}
+      />
+      <Summary />
+    </div>
+  );
+}
+```
+
+### Hide the query override
+
+```jsx
+function Example() {
+  const { search, searchInstant } = useSearch();
+  const { query } = useQuery();
+
+  return (
+    <div className="flex flex-col space-y-3">
+      <Input
+        value={query}
+        onChange={(v) => {
+          search(v);
+          searchInstant(v); // Triggers autocomplete pipeline
+        }}
+      />
+      <Summary showOverride={false} />
+    </div>
+  );
+}
+```

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -22,4 +22,5 @@ export { default as useQuery } from './useQuery';
 export { default as useFilter, FilterItem } from './useFilter';
 export { default as useTracking } from './useTracking';
 export { default as useVariables } from './useVariables';
+export { default as useAutocomplete } from './useAutocomplete';
 export { Token } from '@sajari/sdk-js';

--- a/packages/hooks/src/useAutocomplete/index.ts
+++ b/packages/hooks/src/useAutocomplete/index.ts
@@ -1,0 +1,15 @@
+import { useContext } from '../SearchContextProvider';
+
+function useAutocomplete() {
+  const {
+    instant: { suggestions, search, completion },
+  } = useContext();
+
+  return {
+    suggestions,
+    search,
+    completion,
+  };
+}
+
+export default useAutocomplete;

--- a/packages/search-ui/src/Summary/index.tsx
+++ b/packages/search-ui/src/Summary/index.tsx
@@ -1,18 +1,37 @@
 /* eslint-disable react/jsx-one-expression-per-line */
-import { Text } from '@sajari/react-components';
-import { useSearchContext } from '@sajari/react-hooks';
-import React, { HTMLAttributes } from 'react';
+import { Button, Text } from '@sajari/react-components';
+import { useAutocomplete, useQuery, useSearchContext } from '@sajari/react-hooks';
+import React from 'react';
 
-const Summary = (props: HTMLAttributes<HTMLElement>) => {
-  const { latency, totalResults } = useSearchContext();
+import { SummaryProps } from './types';
+
+const Summary = (props: SummaryProps) => {
+  const { latency, totalResults, search } = useSearchContext();
+  const { showOverride = true, ...rest } = props;
+  const { query } = useQuery();
+  const { completion } = useAutocomplete();
 
   if (!totalResults) {
     return null;
   }
 
   return (
-    <Text {...props}>
-      {totalResults.toLocaleString()} result{totalResults > 1 ? 's' : ''} ({latency} secs)
+    <Text {...rest}>
+      {totalResults.toLocaleString()} result{totalResults > 1 ? 's' : ''}{' '}
+      {query ? (
+        <>
+          for &quot;<strong>{query}</strong>&quot;
+        </>
+      ) : null}{' '}
+      ({latency} secs)
+      {completion && completion !== query.trim() && showOverride ? (
+        <React.Fragment>
+          . Search instead for{' '}
+          <Button onClick={() => search(completion)} spacing="none" appearance="link">
+            {completion}
+          </Button>
+        </React.Fragment>
+      ) : null}
     </Text>
   );
 };

--- a/packages/search-ui/src/Summary/types.ts
+++ b/packages/search-ui/src/Summary/types.ts
@@ -1,0 +1,8 @@
+import { HTMLAttributes } from 'react';
+
+type Props = {
+  /** Show/hide the override text */
+  showOverride?: boolean;
+};
+
+export type SummaryProps = Props & HTMLAttributes<HTMLElement>;


### PR DESCRIPTION
## What this PR does
- [x] Add `useAutocomplete` hook which exposes the `instant` state of the context
- [x] Add option to override query in `<Summary />`